### PR TITLE
Increase DISA Organization max char length

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_organization.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_organization.xml
@@ -9,7 +9,7 @@
         </element>
         <element label="City" max_length="50" name="city" type="string"/>
         <element label="Country" max_length="50" name="country" type="string"/>
-        <element choice="1" display="true" label="DISA Organization" max_length="40" name="disa_organization" type="choice">
+        <element choice="1" display="true" label="DISA Organization" max_length="100" name="disa_organization" type="choice">
             <choice>
                 <element inactive_on_update="false" label="Assistant to the Director (DD)" value="ASSISTANT_TO_THE_DIRECTOR"/>
                 <element inactive_on_update="false" label="Chaplain Program Management Office (DDCH)" value="CHAPLAIN_PROGRAM_MANAGEMENT_OFFICE"/>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_organization_disa_organization.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_organization_disa_organization.xml
@@ -34,7 +34,7 @@
         <function_field>false</function_field>
         <internal_type display_value="Choice">choice</internal_type>
         <mandatory>false</mandatory>
-        <max_length>40</max_length>
+        <max_length>100</max_length>
         <name>x_g_dis_atat_organization</name>
         <next_element/>
         <primary>false</primary>
@@ -53,15 +53,15 @@
         <sys_class_name>sys_dictionary</sys_class_name>
         <sys_created_by>julius.fitzhugh-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-03-08 21:16:48</sys_created_on>
-        <sys_id>9f3068768742c910bc86b889cebb35ec</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_id>334d624b87da01108ea6cbb9cebb350d</sys_id>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name>DISA Organization</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_organization_disa_organization</sys_update_name>
-        <sys_updated_by>julius.fitzhugh-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-03-18 20:04:13</sys_updated_on>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-03-30 17:11:57</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>


### PR DESCRIPTION
The value field was being cut off at 40 and causing
choice values with a name longer than 40 to display
incorrectly and show in blue. Increased max length to 
100 to prevent the DISA org values from being truncated.
