### PR TITLE
SNOW Provisioning Scheduled Job

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_portfolio.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_portfolio.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?><database>
+    <element label="Portfolio" max_length="40" name="x_g_dis_atat_portfolio" type="collection">
+        <element label="Acquisition Package" max_length="32" name="acquisition_package" reference="x_g_dis_atat_acquisition_package" type="reference"/>
+        <element label="Mission Owners" max_length="4000" name="mission_owners" type="glide_list"/>
+        <element display="true" label="Name" max_length="60" name="name" type="string"/>
+        <index name="index">
+            <element name="acquisition_package"/>
+        </index>
+    </element>
+</database>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_app_module_c309332187f601108ea6cbb9cebb3523.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_app_module_c309332187f601108ea6cbb9cebb3523.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update sys_domain="global" table="sys_app_module">
+    <sys_app_module action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <application display_value="Portfolio">f5ede06c1b308110582f2134604bcb35</application>
+        <assessment/>
+        <device_type/>
+        <filter/>
+        <hint/>
+        <homepage/>
+        <image/>
+        <link_type>LIST</link_type>
+        <map_page/>
+        <mobile_title>Portfolios</mobile_title>
+        <mobile_view_name>Mobile</mobile_view_name>
+        <name>x_g_dis_atat_portfolio</name>
+        <order/>
+        <override_menu_roles>false</override_menu_roles>
+        <query/>
+        <report/>
+        <roles>x_g_dis_atat.portfolio_user</roles>
+        <sys_class_name>sys_app_module</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>c309332187f601108ea6cbb9cebb3523</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Portfolios</sys_name>
+        <sys_overrides/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_app_module_c309332187f601108ea6cbb9cebb3523</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+        <timeline_page/>
+        <title>Portfolios</title>
+        <uncancelable>false</uncancelable>
+        <view_name/>
+        <window_name/>
+    </sys_app_module>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_db_object_51787bad87b601108ea6cbb9cebb3583.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_db_object_51787bad87b601108ea6cbb9cebb3583.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_db_object">
+    <sys_db_object action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <actions_access>false</actions_access>
+        <alter_access>false</alter_access>
+        <caller_access/>
+        <client_scripts_access>false</client_scripts_access>
+        <configuration_access>false</configuration_access>
+        <create_access>false</create_access>
+        <create_access_controls>true</create_access_controls>
+        <delete_access>false</delete_access>
+        <extension_model/>
+        <is_extendable>false</is_extendable>
+        <label>Portfolio</label>
+        <live_feed_enabled>false</live_feed_enabled>
+        <name>x_g_dis_atat_portfolio</name>
+        <number_ref/>
+        <provider_class/>
+        <read_access>true</read_access>
+        <scriptable_table>false</scriptable_table>
+        <super_class/>
+        <sys_class_code/>
+        <sys_class_name>sys_db_object</sys_class_name>
+        <sys_class_path/>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_id>51787bad87b601108ea6cbb9cebb3583</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_db_object_51787bad87b601108ea6cbb9cebb3583</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+        <update_access>false</update_access>
+        <user_role display_value="x_g_dis_atat.portfolio_user" name="x_g_dis_atat.portfolio_user">c7093fa987b601108ea6cbb9cebb35b2</user_role>
+        <ws_access>true</ws_access>
+    </sys_db_object>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_acquisition_package.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_acquisition_package.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="acquisition_package" table="x_g_dis_atat_portfolio">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Acquisition Package</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>acquisition_package</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="Reference">reference</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>32</max_length>
+        <name>x_g_dis_atat_portfolio</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference display_value="" name="x_g_dis_atat_acquisition_package">x_g_dis_atat_acquisition_package</reference>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_id>d178f76d87b601108ea6cbb9cebb35d1</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Acquisition Package</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_portfolio_acquisition_package</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_mission_owners.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_mission_owners.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="mission_owners" table="x_g_dis_atat_portfolio">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Mission Owners</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>mission_owners</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="">glide_list</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>4000</max_length>
+        <name>x_g_dis_atat_portfolio</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_id>f4c8bb6d87b601108ea6cbb9cebb35af</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Mission Owners</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_portfolio_mission_owners</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_name.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_name.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="name" table="x_g_dis_atat_portfolio">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Name</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>true</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>name</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="String">string</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>60</max_length>
+        <name>x_g_dis_atat_portfolio</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_id>2f88fbad87b601108ea6cbb9cebb3525</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_name>Name</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_portfolio_name</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:36:45</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_null.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_null.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="" table="x_g_dis_atat_portfolio">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element/>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="Collection">collection</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>40</max_length>
+        <name>x_g_dis_atat_portfolio</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>5b09332187f601108ea6cbb9cebb3544</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_portfolio_null</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio__en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio__en.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="" label="Portfolio" language="en" table="x_g_dis_atat_portfolio">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element/>
+            <help/>
+            <hint/>
+            <label>Portfolio</label>
+            <language>en</language>
+            <name>x_g_dis_atat_portfolio</name>
+            <plural>Portfolios</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+            <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+            <sys_id>9309332187f601108ea6cbb9cebb354c</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Portfolio</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_portfolio__en</sys_update_name>
+            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+            <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_acquisition_package_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_acquisition_package_en.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="acquisition_package" label="Acquisition Package" language="en" table="x_g_dis_atat_portfolio">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>acquisition_package</element>
+            <help/>
+            <hint/>
+            <label>Acquisition Package</label>
+            <language>en</language>
+            <name>x_g_dis_atat_portfolio</name>
+            <plural>Acquisition Packages</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+            <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+            <sys_id>1309332187f601108ea6cbb9cebb354f</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Acquisition Package</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_portfolio_acquisition_package_en</sys_update_name>
+            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+            <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_mission_owners_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_mission_owners_en.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="mission_owners" label="Mission Owners" language="en" table="x_g_dis_atat_portfolio">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>mission_owners</element>
+            <help/>
+            <hint/>
+            <label>Mission Owners</label>
+            <language>en</language>
+            <name>x_g_dis_atat_portfolio</name>
+            <plural>Mission Owners</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+            <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+            <sys_id>5f09332187f601108ea6cbb9cebb355c</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Mission Owners</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_portfolio_mission_owners_en</sys_update_name>
+            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+            <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_name_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_portfolio_name_en.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="name" label="Name" language="en" table="x_g_dis_atat_portfolio">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>name</element>
+            <help/>
+            <hint/>
+            <label>Name</label>
+            <language>en</language>
+            <name>x_g_dis_atat_portfolio</name>
+            <plural>Names</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+            <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+            <sys_id>5f09332187f601108ea6cbb9cebb355d</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Name</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_portfolio_name_en</sys_update_name>
+            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+            <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_script_include">
+    <sys_script_include action="INSERT_OR_UPDATE">
+        <access>package_private</access>
+        <active>true</active>
+        <api_name>x_g_dis_atat.getProvisioningJobResults</api_name>
+        <caller_access/>
+        <client_callable>false</client_callable>
+        <description>A function to be used for a scheduled job that makes a GET request to AWS and gets the provisioning job results from the provisioning queue.</description>
+        <name>getProvisioningJobResults</name>
+        <script><![CDATA[function getProvisioningJobResults() {
+	
+	try {
+
+		var getProvisioningJobsRequest = new sn_ws.RESTMessageV2();
+
+		// AWS request setup
+		var baseUrl = new GlideRecord('x_g_dis_atat_configuration');
+		baseUrl.get('name', 'provisioning_api_endpoint');
+		var URL = baseUrl.value + 'provisioning-jobs';
+		gs.info('URL: ' + URL);
+		getProvisioningJobsRequest.setEndpoint(URL);
+		getProvisioningJobsRequest.setHttpMethod('get');
+		getProvisioningJobsRequest.setLogLevel('all');
+
+		// make request
+		var response = getProvisioningJobsRequest.execute();
+		var responseBody = JSON.parse(response.getBody());
+		var status = response.getStatusCode();
+		
+		// loop through each job (can be empty)
+		for (var i = 0; i <= responseBody.length - 1; i++) {
+			// get provisioning job (jobId -> sys_id)
+			var jobMessage = responseBody[i];
+			var provisioningRecord = new GlideRecord('x_g_dis_atat_provisioning_job');
+			provisioningRecord.get(jobMessage.jobId);
+
+			// update job status and add 'status message' if an error
+			if (jobMessage.cspResponse.code == '200') {
+				provisioningRecord.status = 'SUCCESS';
+				provisioningRecord.update();
+
+				// get Mission Owner ID from m2m record			
+				var m2mRecord = new GlideRecord('x_g_dis_atat_m2m_contacts_acquisition');
+				m2mRecord.get('acquisition_package', provisioningRecord.acquisition_package);
+
+				// create a portfolio record and referece Acq Package
+				var portfolio = new GlideRecord('x_g_dis_atat_portfolio');
+				portfolio.initialize();
+				portfolio.acquisition_package = provisioningRecord.acquisition_package;
+				portfolio.name = jobMessage.payload.name;
+
+				// a 'List' field type is just a comma separated string
+				portfolio.mission_owners = m2mRecord.contacts.toString();
+				portfolio.insert();
+
+			} else {
+				provisioningRecord.status = 'FAILURE';
+				// 400 errors get put on the queue
+				// 500 errors do not get put on the queue at all
+				provisioningRecord.status_message = jobMessage.message;
+				provisioningRecord.update();
+			}
+
+		}
+	} catch(error) {
+		gs.error('Internal SNOW error => ' + error);
+		gs.error('Error Stack => ' + error.stack);
+	}
+}]]></script>
+        <sys_class_name>sys_script_include</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-13 17:23:41</sys_created_on>
+        <sys_id>a550095a87b241108ea6cbb9cebb35ec</sys_id>
+        <sys_mod_count>9</sys_mod_count>
+        <sys_name>getProvisioningJobResults</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy>read</sys_policy>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_script_include_a550095a87b241108ea6cbb9cebb35ec</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-13 22:56:49</sys_updated_on>
+    </sys_script_include>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
@@ -10,14 +10,13 @@
         <script><![CDATA[function getProvisioningJobResults() {
 	
 	try {
-
+		// outbound REST message
 		var getProvisioningJobsRequest = new sn_ws.RESTMessageV2();
 
 		// AWS request setup
 		var baseUrl = new GlideRecord('x_g_dis_atat_configuration');
 		baseUrl.get('name', 'provisioning_api_endpoint');
 		var URL = baseUrl.value + 'provisioning-jobs';
-		gs.info('URL: ' + URL);
 		getProvisioningJobsRequest.setEndpoint(URL);
 		getProvisioningJobsRequest.setHttpMethod('get');
 		getProvisioningJobsRequest.setLogLevel('all');
@@ -26,16 +25,21 @@
 		var response = getProvisioningJobsRequest.execute();
 		var responseBody = JSON.parse(response.getBody());
 		var status = response.getStatusCode();
+		if (responseBody.length == 0) {
+			gs.info("No messages in Provisioning Job Queue.");
+			return;
+		}
 		
-		// loop through each job (can be empty)
+		// loop through each job
 		for (var i = 0; i <= responseBody.length - 1; i++) {
 			// get provisioning job (jobId -> sys_id)
 			var jobMessage = responseBody[i];
 			var provisioningRecord = new GlideRecord('x_g_dis_atat_provisioning_job');
 			provisioningRecord.get(jobMessage.jobId);
-
-			// update job status and add 'status message' if an error
-			if (jobMessage.cspResponse.code == '200') {
+			
+			if (jobMessage.cspResponse.code == '200' && 
+				provisioningRecord.job_type == 'ADD_PORTFOLIO') {
+				// update job status
 				provisioningRecord.status = 'SUCCESS';
 				provisioningRecord.update();
 
@@ -53,11 +57,16 @@
 				portfolio.mission_owners = m2mRecord.contacts.toString();
 				portfolio.insert();
 
-			} else {
+			} else if (jobMessage.cspResponse.code == '400') {
+				// update job status and status message
+				// only 400 errors get put on the queue (not 500 errors)
 				provisioningRecord.status = 'FAILURE';
-				// 400 errors get put on the queue
-				// 500 errors do not get put on the queue at all
 				provisioningRecord.status_message = JSON.stringify(jobMessage.cspResponse);
+				provisioningRecord.update();
+			} else {
+				// catch everything else
+				gs.info('Unknown status from provisioning request.');
+				provisioningRecord.status = 'FAILURE';
 				provisioningRecord.update();
 			}
 
@@ -71,13 +80,13 @@
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2022-04-13 17:23:41</sys_created_on>
         <sys_id>a550095a87b241108ea6cbb9cebb35ec</sys_id>
-        <sys_mod_count>11</sys_mod_count>
+        <sys_mod_count>16</sys_mod_count>
         <sys_name>getProvisioningJobResults</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_a550095a87b241108ea6cbb9cebb35ec</sys_update_name>
         <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2022-04-14 00:12:58</sys_updated_on>
+        <sys_updated_on>2022-04-14 04:01:59</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_a550095a87b241108ea6cbb9cebb35ec.xml
@@ -57,7 +57,7 @@
 				provisioningRecord.status = 'FAILURE';
 				// 400 errors get put on the queue
 				// 500 errors do not get put on the queue at all
-				provisioningRecord.status_message = jobMessage.message;
+				provisioningRecord.status_message = JSON.stringify(jobMessage.cspResponse);
 				provisioningRecord.update();
 			}
 
@@ -71,13 +71,13 @@
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2022-04-13 17:23:41</sys_created_on>
         <sys_id>a550095a87b241108ea6cbb9cebb35ec</sys_id>
-        <sys_mod_count>9</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_name>getProvisioningJobResults</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_a550095a87b241108ea6cbb9cebb35ec</sys_update_name>
         <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2022-04-13 22:56:49</sys_updated_on>
+        <sys_updated_on>2022-04-14 00:12:58</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_1709332187f601108ea6cbb9cebb3532.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_1709332187f601108ea6cbb9cebb3532.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl">
+    <sys_security_acl action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <admin_overrides>true</admin_overrides>
+        <advanced>false</advanced>
+        <condition/>
+        <description>Default access control on x_g_dis_atat_portfolio</description>
+        <name>x_g_dis_atat_portfolio</name>
+        <operation display_value="read">read</operation>
+        <script/>
+        <sys_class_name>sys_security_acl</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>1709332187f601108ea6cbb9cebb3532</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_security_acl_1709332187f601108ea6cbb9cebb3532</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <type display_value="record">record</type>
+    </sys_security_acl>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_1b09332187f601108ea6cbb9cebb353e.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_1b09332187f601108ea6cbb9cebb353e.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl">
+    <sys_security_acl action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <admin_overrides>true</admin_overrides>
+        <advanced>false</advanced>
+        <condition/>
+        <description>Default access control on x_g_dis_atat_portfolio</description>
+        <name>x_g_dis_atat_portfolio</name>
+        <operation display_value="delete">delete</operation>
+        <script/>
+        <sys_class_name>sys_security_acl</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>1b09332187f601108ea6cbb9cebb353e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_security_acl_1b09332187f601108ea6cbb9cebb353e</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <type display_value="record">record</type>
+    </sys_security_acl>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_8709332187f601108ea6cbb9cebb352a.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_8709332187f601108ea6cbb9cebb352a.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl">
+    <sys_security_acl action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <admin_overrides>true</admin_overrides>
+        <advanced>false</advanced>
+        <condition/>
+        <description>Default access control on x_g_dis_atat_portfolio</description>
+        <name>x_g_dis_atat_portfolio</name>
+        <operation display_value="create">create</operation>
+        <script/>
+        <sys_class_name>sys_security_acl</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>8709332187f601108ea6cbb9cebb352a</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_security_acl_8709332187f601108ea6cbb9cebb352a</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <type display_value="record">record</type>
+    </sys_security_acl>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_9709332187f601108ea6cbb9cebb3538.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_9709332187f601108ea6cbb9cebb3538.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl">
+    <sys_security_acl action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <admin_overrides>true</admin_overrides>
+        <advanced>false</advanced>
+        <condition/>
+        <description>Default access control on x_g_dis_atat_portfolio</description>
+        <name>x_g_dis_atat_portfolio</name>
+        <operation display_value="write">write</operation>
+        <script/>
+        <sys_class_name>sys_security_acl</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>9709332187f601108ea6cbb9cebb3538</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_security_acl_9709332187f601108ea6cbb9cebb3538</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <type display_value="record">record</type>
+    </sys_security_acl>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_5709332187f601108ea6cbb9cebb3535.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_5709332187f601108ea6cbb9cebb3535.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl_role">
+    <sys_security_acl_role action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_security_acl_role</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>5709332187f601108ea6cbb9cebb3535</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio.x_g_dis_atat.portfolio_user</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_security_acl display_value="x_g_dis_atat_portfolio">1709332187f601108ea6cbb9cebb3532</sys_security_acl>
+        <sys_update_name>sys_security_acl_role_5709332187f601108ea6cbb9cebb3535</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <sys_user_role display_value="x_g_dis_atat.portfolio_user" name="x_g_dis_atat.portfolio_user">c7093fa987b601108ea6cbb9cebb35b2</sys_user_role>
+        <transaction_id/>
+    </sys_security_acl_role>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_5b09332187f601108ea6cbb9cebb3541.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_5b09332187f601108ea6cbb9cebb3541.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl_role">
+    <sys_security_acl_role action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_security_acl_role</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>5b09332187f601108ea6cbb9cebb3541</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio.x_g_dis_atat.portfolio_user</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_security_acl display_value="x_g_dis_atat_portfolio">1b09332187f601108ea6cbb9cebb353e</sys_security_acl>
+        <sys_update_name>sys_security_acl_role_5b09332187f601108ea6cbb9cebb3541</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <sys_user_role display_value="x_g_dis_atat.portfolio_user" name="x_g_dis_atat.portfolio_user">c7093fa987b601108ea6cbb9cebb35b2</sys_user_role>
+        <transaction_id/>
+    </sys_security_acl_role>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_c709332187f601108ea6cbb9cebb352e.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_c709332187f601108ea6cbb9cebb352e.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl_role">
+    <sys_security_acl_role action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_security_acl_role</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>c709332187f601108ea6cbb9cebb352e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio.x_g_dis_atat.portfolio_user</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_security_acl display_value="x_g_dis_atat_portfolio">8709332187f601108ea6cbb9cebb352a</sys_security_acl>
+        <sys_update_name>sys_security_acl_role_c709332187f601108ea6cbb9cebb352e</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <sys_user_role display_value="x_g_dis_atat.portfolio_user" name="x_g_dis_atat.portfolio_user">c7093fa987b601108ea6cbb9cebb35b2</sys_user_role>
+        <transaction_id/>
+    </sys_security_acl_role>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_d709332187f601108ea6cbb9cebb353b.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_security_acl_role_d709332187f601108ea6cbb9cebb353b.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_security_acl_role">
+    <sys_security_acl_role action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_security_acl_role</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:44</sys_created_on>
+        <sys_id>d709332187f601108ea6cbb9cebb353b</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat_portfolio.x_g_dis_atat.portfolio_user</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_security_acl display_value="x_g_dis_atat_portfolio">9709332187f601108ea6cbb9cebb3538</sys_security_acl>
+        <sys_update_name>sys_security_acl_role_d709332187f601108ea6cbb9cebb353b</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:44</sys_updated_on>
+        <sys_user_role display_value="x_g_dis_atat.portfolio_user" name="x_g_dis_atat.portfolio_user">c7093fa987b601108ea6cbb9cebb35b2</sys_user_role>
+        <transaction_id/>
+    </sys_security_acl_role>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_module_4309332187f601108ea6cbb9cebb3527.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_module_4309332187f601108ea6cbb9cebb3527.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update sys_domain="global" table="sys_ui_module">
+    <sys_ui_module action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <application display_value="Portfolio">f9ede06c1b308110582f2134604bcb3c</application>
+        <filter/>
+        <name>Portfolios</name>
+        <order/>
+        <path/>
+        <path_relative_to_root>false</path_relative_to_root>
+        <roles>x_g_dis_atat.portfolio_user</roles>
+        <sys_class_name>sys_ui_module</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>4309332187f601108ea6cbb9cebb3527</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Portfolios</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ui_module_4309332187f601108ea6cbb9cebb3527</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+        <table>x_g_dis_atat_portfolio</table>
+        <uncancelable>false</uncancelable>
+        <view_name/>
+    </sys_ui_module>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_286c755c877241108ea6cbb9cebb3570.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_286c755c877241108ea6cbb9cebb3570.xml
@@ -1,100 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?><record_update>
     <sys_ui_section caption="" section_id="286c755c877241108ea6cbb9cebb3570" sys_domain="global" table="x_g_dis_atat_provisioning_job" version="3" view="">
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>.begin_split</element>
+            <element>acquisition_package</element>
             <position>0</position>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>ec6c755c877241108ea6cbb9cebb3577</sys_id>
+            <sys_created_on>2022-04-14 00:05:11</sys_created_on>
+            <sys_id>a7e0e21a87f641108ea6cbb9cebb35f9</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
-            <sys_user/>
-            <type>.begin_split</type>
-        </sys_ui_element>
-        <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>acquisition_package</element>
-            <position>1</position>
-            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>e46c755c877241108ea6cbb9cebb3578</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_ui_formatter/>
-            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
-            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
+            <sys_updated_on>2022-04-14 00:05:11</sys_updated_on>
             <sys_user/>
             <type/>
         </sys_ui_element>
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>job_type</element>
-            <position>2</position>
+            <element>status</element>
+            <position>1</position>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>686c755c877241108ea6cbb9cebb3578</sys_id>
+            <sys_created_on>2022-04-14 00:05:11</sys_created_on>
+            <sys_id>6fe0e21a87f641108ea6cbb9cebb35f9</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
+            <sys_updated_on>2022-04-14 00:05:11</sys_updated_on>
             <sys_user/>
             <type/>
         </sys_ui_element>
         <sys_ui_element action="INSERT_OR_UPDATE">
             <element>.split</element>
-            <position>3</position>
+            <position>2</position>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>e86c755c877241108ea6cbb9cebb3578</sys_id>
+            <sys_created_on>2022-04-14 00:05:11</sys_created_on>
+            <sys_id>efe0e21a87f641108ea6cbb9cebb35f9</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
+            <sys_updated_on>2022-04-14 00:05:11</sys_updated_on>
             <sys_user/>
             <type>.split</type>
         </sys_ui_element>
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>status</element>
-            <position>4</position>
+            <element>job_type</element>
+            <position>3</position>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>6c6c755c877241108ea6cbb9cebb3578</sys_id>
+            <sys_created_on>2022-04-14 00:05:11</sys_created_on>
+            <sys_id>63e0e21a87f641108ea6cbb9cebb35fa</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
+            <sys_updated_on>2022-04-14 00:05:11</sys_updated_on>
             <sys_user/>
             <type/>
         </sys_ui_element>
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>.end_split</element>
-            <position>5</position>
-            <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>ec6c755c877241108ea6cbb9cebb3578</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_ui_formatter/>
-            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
-            <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
-            <sys_user/>
-            <type>.end_split</type>
-        </sys_ui_element>
-        <sys_ui_element action="INSERT_OR_UPDATE">
             <element>status_message</element>
-            <position>6</position>
+            <position>4</position>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:40</sys_created_on>
-            <sys_id>606c755c877241108ea6cbb9cebb3579</sys_id>
+            <sys_created_on>2022-04-14 00:05:11</sys_created_on>
+            <sys_id>e3e0e21a87f641108ea6cbb9cebb35fa</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_provisioning_job" sys_domain="global" view="Default view">286c755c877241108ea6cbb9cebb3570</sys_ui_section>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:40</sys_updated_on>
+            <sys_updated_on>2022-04-14 00:05:11</sys_updated_on>
             <sys_user/>
             <type/>
         </sys_ui_element>
@@ -105,7 +77,7 @@
             <roles/>
             <sys_class_name>sys_ui_section</sys_class_name>
             <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-            <sys_created_on>2022-04-07 16:17:39</sys_created_on>
+            <sys_created_on>2022-04-11 21:42:11</sys_created_on>
             <sys_domain>global</sys_domain>
             <sys_domain_path>/</sys_domain_path>
             <sys_id>286c755c877241108ea6cbb9cebb3570</sys_id>
@@ -117,7 +89,7 @@
             <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
             <sys_update_name>sys_ui_section_286c755c877241108ea6cbb9cebb3570</sys_update_name>
             <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-            <sys_updated_on>2022-04-07 16:17:39</sys_updated_on>
+            <sys_updated_on>2022-04-11 21:42:11</sys_updated_on>
             <sys_user/>
             <title>true</title>
             <view display_value="Default view" name="NULL">Default view</view>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_user_role_c7093fa987b601108ea6cbb9cebb35b2.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_user_role_c7093fa987b601108ea6cbb9cebb35b2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_user_role">
+    <sys_user_role action="INSERT_OR_UPDATE">
+        <assignable_by/>
+        <can_delegate>true</can_delegate>
+        <description/>
+        <elevated_privilege>false</elevated_privilege>
+        <grantable>true</grantable>
+        <includes_roles/>
+        <name>x_g_dis_atat.portfolio_user</name>
+        <requires_subscription>-1</requires_subscription>
+        <scoped_admin>false</scoped_admin>
+        <suffix>portfolio_user</suffix>
+        <sys_class_name>sys_user_role</sys_class_name>
+        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
+        <sys_created_on>2022-04-11 22:34:43</sys_created_on>
+        <sys_id>c7093fa987b601108ea6cbb9cebb35b2</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>x_g_dis_atat.portfolio_user</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_user_role_c7093fa987b601108ea6cbb9cebb35b2</sys_update_name>
+        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
+        <sys_updated_on>2022-04-11 22:34:43</sys_updated_on>
+    </sys_user_role>
+</record_update>


### PR DESCRIPTION
Provide a scheduled job to poll the provisioning queue and update SNOW records.
- `getProvisioningJobResults` - a function with logic (see code inside of studio or
in the `sys_script_include` file in https://github.com/dod-ccpo/atat-snow/pull/25/commits/6820be09cdcd4bb1f81b310bac9eba49c556c3ba)
- `Get Provisioning Job Results from AWS` - a *scheduled script execution* that 
calls the function (see file inside of studio)
  - scheduled job is inactive and runs every 30 mins (check `active` to see repeat interval)

![ScheduledJobExec_AT-7057](https://user-images.githubusercontent.com/89867104/163292939-be901e38-f2ab-4f77-8622-58ff5c2a4f4b.png)


### Additional Context
A script includes function `getProvisioningJobResults` was created to manage the logic
of polling the provisioning queue and updating the different records associate with the
polled messages. This was done so that a global `Scheduled Script Execution` can call the 
function while still having the logic contained in the `ATAT` application source control . 
From my understanding if the logic is placed in the `Scheduled Script Execution` file it will 
be global and not available in source control.

Ideally this same logic can be done in a flow which can be seen if you check out the branch 
[feature/AT-7057-provisioning-results-flow](https://github.com/dod-ccpo/atat-snow/tree/feature/AT-7057-provisioning-results-flow) in the DISA storefront but requires a [plugin](https://developer.servicenow.com/dev.do#!/learn/courses/rome/app_store_learnv2_rest_rome_rest_integrations/app_store_learnv2_rest_rome_data_stream_actions/app_store_learnv2_rest_rome_activating_the_integrationhub_enterprise_pack) 
to be activated. The plugin allows for a [JSON parser step](https://docs.servicenow.com/bundle/paris-servicenow-platform/page/administer/flow-designer/reference/json-parser-step-action-designer.html) in actions.

Ticket: AT-7057