### PR TITLE
Only give the PR test workflow read access

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   secretScan:
     name: Scan for secrets


### PR DESCRIPTION
The default the [permissions on the GitHub token][1] grant a lot more
access than is actually required as part of this workflow, especially
for PRs that originate from within this repository. Because the
`GITHUB_TOKEN` is accessible not only via `secrets.GITHUB_TOKEN` but
also on the context object as `github.token`, theoretically, other
actions in use could access the secret. Limiting the permissions is a
good idea.

[1]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
