### PR TITLE
Fixup issue.createComment parameter names

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -60,8 +60,8 @@ jobs:
             `;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
-              name: context.repo.repo,
-              number: context.payload.pull_request.number,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
               body: message,
             });
 
@@ -82,8 +82,8 @@ jobs:
             `;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
-              name: context.repo.repo,
-              number: context.payload.pull_request.number,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
               body: message,
             });
 
@@ -102,7 +102,7 @@ jobs:
             `;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
-              name: context.repo.repo,
-              number: context.payload.pull_request.number,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
               body: message,
             });


### PR DESCRIPTION
These are different than the ones used for the GraphQL PR API. Oops. See
https://octokit.github.io/rest.js/v18#issues-create-comment
