### PR TITLE
Allow commits performed by users on GitHub

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -41,7 +41,7 @@ jobs:
             // Get unique email addresses
             const commitEmails = [... new Set(result.repository.pullRequest.commits.nodes.map((node) => node.commit.author.email))];
             // Check that all emails end in "@ccpo.mil"
-            const allEmailCcpo = commitEmails.every((email) => email.endsWith("@ccpo.mil"));
+            const allEmailCcpo = commitEmails.every((email) => email.endsWith("@ccpo.mil") || email.endsWith("@users.noreply.github.com"));
 
             core.setOutput("commit-count", totalCommits);
             core.setOutput("all-email-ccpo", allEmailCcpo);


### PR DESCRIPTION
This avoids an "external users" comment when a commit was created on the
GitHub UI (such as a merge commit, etc).
