### PR TITLE
Update config table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,3 @@ If you find yourself unable to import your repository due to the presence of fil
   4. Run `git add -A`
   5. Run `git commit`
   6. Run `git push`
-
- **Notes on dependencies**
-  1. Dependencies will not show up in the list of changes but will be exported/imported
-  2. It is your responsibility to resolve the dependencies before installing an application. ServiceNow source control will not manage these for you. In case you installed an application before installing its dependencies:
-   2.1 Delete the application
-   2.2 Activate/install all required dependencies
-   2.3 Re-import the application from source control
-   Currently listed dependencies:
-   * System Import Sets

--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_configuration.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><database>
-    <element label="ATAT Configuration" max_length="40" name="x_g_dis_atat_configuration" type="collection">
-        <element display="true" label="Description" max_length="300" name="description" type="string"/>
-        <element label="Name" max_length="100" name="name" type="string"/>
+    <element label="ATAT Configuration" max_length="40" name="x_g_dis_atat_configuration" sizeclass="0" type="collection">
+        <element label="Description" max_length="300" name="description" type="string"/>
+        <element display="true" label="Name" max_length="100" name="name" type="string"/>
         <element label="Value" max_length="300" name="value" type="string"/>
     </element>
 </database>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_configuration_description.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_configuration_description.xml
@@ -22,7 +22,7 @@
         <delete_roles/>
         <dependent/>
         <dependent_on_field/>
-        <display>true</display>
+        <display>false</display>
         <dynamic_creation>false</dynamic_creation>
         <dynamic_creation_script/>
         <dynamic_default_value/>
@@ -53,7 +53,7 @@
         <sys_class_name>sys_dictionary</sys_class_name>
         <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-04-08 18:06:22</sys_created_on>
-        <sys_id>0dbed36887724510bc86b889cebb3587</sys_id>
+        <sys_id>04f8229a87330110fb40a68d0ebb35f4</sys_id>
         <sys_mod_count>1</sys_mod_count>
         <sys_name>Description</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -61,7 +61,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_configuration_description</sys_update_name>
         <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-04-08 18:10:29</sys_updated_on>
+        <sys_updated_on>2022-07-12 16:53:58</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_configuration_name.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_configuration_name.xml
@@ -22,7 +22,7 @@
         <delete_roles/>
         <dependent/>
         <dependent_on_field/>
-        <display>false</display>
+        <display>true</display>
         <dynamic_creation>false</dynamic_creation>
         <dynamic_creation_script/>
         <dynamic_default_value/>
@@ -53,15 +53,15 @@
         <sys_class_name>sys_dictionary</sys_class_name>
         <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-04-08 18:06:22</sys_created_on>
-        <sys_id>c65ed7a887724510bc86b889cebb3540</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_id>04f8629a87330110fb40a68d0ebb3502</sys_id>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name>Name</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_configuration_name</sys_update_name>
         <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-04-08 18:10:59</sys_updated_on>
+        <sys_updated_on>2022-07-12 16:53:58</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_list_x_g_dis_atat_configuration_null.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_list_x_g_dis_atat_configuration_null.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_ui_list parent="" relationship="" sys_domain="global" table="x_g_dis_atat_configuration" version="2" view="">
+        <sys_ui_list_element action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element>name</element>
+            <list_id display_value="x_g_dis_atat_configuration" element="NULL" name="x_g_dis_atat_configuration" parent="NULL" relationship="NULL" sys_domain="global" view="Default view">2afd101787605110fb40a68d0ebb3520</list_id>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <position>0</position>
+            <sum>false</sum>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_id>62fd101787605110fb40a68d0ebb3522</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+        </sys_ui_list_element>
+        <sys_ui_list_element action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element>value</element>
+            <list_id display_value="x_g_dis_atat_configuration" element="NULL" name="x_g_dis_atat_configuration" parent="NULL" relationship="NULL" sys_domain="global" view="Default view">2afd101787605110fb40a68d0ebb3520</list_id>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <position>1</position>
+            <sum>false</sum>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_id>2afd101787605110fb40a68d0ebb3522</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+        </sys_ui_list_element>
+        <sys_ui_list_element action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element>description</element>
+            <list_id display_value="x_g_dis_atat_configuration" element="NULL" name="x_g_dis_atat_configuration" parent="NULL" relationship="NULL" sys_domain="global" view="Default view">2afd101787605110fb40a68d0ebb3520</list_id>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <position>2</position>
+            <sum>false</sum>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_id>aafd101787605110fb40a68d0ebb3522</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+        </sys_ui_list_element>
+        <sys_ui_list_element action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element>sys_updated_on</element>
+            <list_id display_value="x_g_dis_atat_configuration" element="NULL" name="x_g_dis_atat_configuration" parent="NULL" relationship="NULL" sys_domain="global" view="Default view">2afd101787605110fb40a68d0ebb3520</list_id>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <position>3</position>
+            <sum>false</sum>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_id>2efd101787605110fb40a68d0ebb3522</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+        </sys_ui_list_element>
+        <sys_ui_list_element action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element>sys_updated_by</element>
+            <list_id display_value="x_g_dis_atat_configuration" element="NULL" name="x_g_dis_atat_configuration" parent="NULL" relationship="NULL" sys_domain="global" view="Default view">2afd101787605110fb40a68d0ebb3520</list_id>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <position>4</position>
+            <sum>false</sum>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_id>aefd101787605110fb40a68d0ebb3522</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+        </sys_ui_list_element>
+        <sys_ui_list action="INSERT_OR_UPDATE">
+            <average_value>false</average_value>
+            <element/>
+            <max_value>false</max_value>
+            <min_value>false</min_value>
+            <name>x_g_dis_atat_configuration</name>
+            <parent/>
+            <position/>
+            <relationship/>
+            <sum>false</sum>
+            <sys_class_name>sys_ui_list</sys_class_name>
+            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
+            <sys_created_on>2022-07-12 16:56:51</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>2afd101787605110fb40a68d0ebb3520</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>x_g_dis_atat_configuration</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_ui_list_x_g_dis_atat_configuration_null</sys_update_name>
+            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
+            <sys_updated_on>2022-07-12 16:56:51</sys_updated_on>
+            <sys_user/>
+            <view display_value="Default view" name="NULL">Default view</view>
+            <view_name/>
+        </sys_ui_list>
+    </sys_ui_list>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_371f5be887724510bc86b889cebb35ff.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_371f5be887724510bc86b889cebb35ff.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?><record_update>
     <sys_ui_section caption="" section_id="371f5be887724510bc86b889cebb35ff" sys_domain="global" table="x_g_dis_atat_configuration" version="3" view="">
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>.begin_split</element>
+            <element>name</element>
             <position>0</position>
             <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>f31fdfe887724510bc86b889cebb359b</sys_id>
+            <sys_created_on>2022-07-12 17:05:33</sys_created_on>
+            <sys_id>46ff549787605110fb40a68d0ebb3586</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
             <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
+            <sys_updated_on>2022-07-12 17:05:33</sys_updated_on>
             <sys_user/>
-            <type>.begin_split</type>
+            <type/>
         </sys_ui_element>
         <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>name</element>
+            <element>value</element>
             <position>1</position>
             <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>771fdfe887724510bc86b889cebb359b</sys_id>
+            <sys_created_on>2022-07-12 17:05:33</sys_created_on>
+            <sys_id>c6ff549787605110fb40a68d0ebb3586</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
             <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
+            <sys_updated_on>2022-07-12 17:05:33</sys_updated_on>
             <sys_user/>
             <type/>
         </sys_ui_element>
@@ -32,57 +32,15 @@
             <element>description</element>
             <position>2</position>
             <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>f71fdfe887724510bc86b889cebb359b</sys_id>
+            <sys_created_on>2022-07-12 17:05:33</sys_created_on>
+            <sys_id>4aff549787605110fb40a68d0ebb3586</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_ui_formatter/>
             <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
             <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
+            <sys_updated_on>2022-07-12 17:05:33</sys_updated_on>
             <sys_user/>
             <type/>
-        </sys_ui_element>
-        <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>.split</element>
-            <position>3</position>
-            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>7b1fdfe887724510bc86b889cebb359b</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_ui_formatter/>
-            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
-            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
-            <sys_user/>
-            <type>.split</type>
-        </sys_ui_element>
-        <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>value</element>
-            <position>4</position>
-            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>fb1fdfe887724510bc86b889cebb359b</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_ui_formatter/>
-            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
-            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
-            <sys_user/>
-            <type/>
-        </sys_ui_element>
-        <sys_ui_element action="INSERT_OR_UPDATE">
-            <element>.end_split</element>
-            <position>5</position>
-            <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-            <sys_created_on>2022-04-08 18:07:31</sys_created_on>
-            <sys_id>7f1fdfe887724510bc86b889cebb359b</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_ui_formatter/>
-            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_configuration" sys_domain="global" view="Default view">371f5be887724510bc86b889cebb35ff</sys_ui_section>
-            <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-            <sys_updated_on>2022-04-08 18:07:31</sys_updated_on>
-            <sys_user/>
-            <type>.end_split</type>
         </sys_ui_element>
         <sys_ui_section action="INSERT_OR_UPDATE">
             <caption/>


### PR DESCRIPTION
Includes minor improvements to the ATAT Configuration table and its representations

1. Set SNOW _Display_ field to `Name` column - this will now be shown when selecting configuration entries
2. Adjust columns displayed in list layout - reordered columns, and added last updated and by whom to be show by default
3. Adjust form layout - simplified layout

![image](https://user-images.githubusercontent.com/77642966/178552363-c062c4ef-341e-48a6-b00b-f1cbc3c4e061.png)

![image](https://user-images.githubusercontent.com/77642966/178552597-084cc61f-77c1-420b-92bd-e59e71f942e8.png)

![image](https://user-images.githubusercontent.com/77642966/178552762-9ea89f2e-7dfa-4738-baf7-3525157ed1bc.png)
