### PR TITLE
Add docs folder at top level

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Generated files
-This repository contains generated files and a checksum.
+This repository contains generated files inside of `f600233d1b154d507b782f84604bcb12` and a checksum.
 
 If you find yourself unable to import your repository due to the presence of files edited outside an instance of ServiceNow, merge commits that mix files from different revisions, or other data that does not match the checksum, you may recover using either of the following techniques:
 * Remove the problem commits:
@@ -16,3 +16,12 @@ If you find yourself unable to import your repository due to the presence of fil
   4. Run `git add -A`
   5. Run `git commit`
   6. Run `git push`
+
+ **Notes on dependencies**
+  1. Dependencies will not show up in the list of changes but will be exported/imported
+  2. It is your responsibility to resolve the dependencies before installing an application. ServiceNow source control will not manage these for you. In case you installed an application before installing its dependencies:
+   2.1 Delete the application
+   2.2 Activate/install all required dependencies
+   2.3 Re-import the application from source control
+   Currently listed dependencies:
+   * System Import Sets


### PR DESCRIPTION
The README.md file inside of the f600233d1b154d507b782f84604bcb12
folder continues to remove the end of the file. To prevent this
it has been moved to the docs/ folder at the top level, since
generated files are found in f600233d1b154d507b782f84604bcb12 and
is considered less reliable.
