### PR TITLE
Update GitHub actions to run on Node 16

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
           architecture: "x64"


### PR DESCRIPTION
- Updates GitHub actions to use newer versions that run on Node 16.  [Older actions that run on Node 12 are deprecated.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

Resolves this warning on PR check executions
![image](https://user-images.githubusercontent.com/77642966/211871158-35ddadc3-331f-45b6-b2cd-73082599974c.png)
