### PR TITLE
Feature AT 9565 - Fix for business rule logic; only email unique operators in unclassif…

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
@@ -33,7 +33,7 @@
 
     // portfolio is 'current'; get portfolio sys_id
     const portfolioSysId = current.sys_id;
-    gs.info(`portfolioSysId: ${portfolioSysId}`);
+    //gs.info(`portfolioSysId: ${portfolioSysId}`);
     // use portfolio sys_id; retrieve environments for portfolio (using sys_id) that are unclassified
     const environmentGR = new GlideRecord('x_g_dis_atat_environment');
     environmentGR.addQuery('portfolio', portfolioSysId);
@@ -45,18 +45,18 @@
     // iterate through environments; extract operator email
     while (environmentGR.next()) {
         const pendingOperators = environmentGR.getValue('pending_operators');
-		gs.info(`pendingOperators: ${pendingOperators}`);
+		//gs.info(`pendingOperators: ${pendingOperators}`);
         const operatorGR = new GlideRecord('x_g_dis_atat_operator');
 		operatorGR.get(pendingOperators);
 		const email = operatorGR.email;
-		gs.info(`Operator Email: ${email}`);
+		//gs.info(`Operator Email: ${email}`);
 		operatorEmails.push(email);
     }
 
     // remove duplicated emails
-    gs.info(`operatorEmails: ${operatorEmails.toString()}`);
+    //gs.info(`operatorEmails: ${operatorEmails.toString()}`);
     const uniqueEmails = operatorEmails.filter((email, index) => operatorEmails.indexOf(email) === index);
-    gs.info(`uniqueEmails: ${uniqueEmails.toString()}`);
+    //gs.info(`uniqueEmails: ${uniqueEmails.toString()}`);
 
     return gs.eventQueue('x_g_dis_atat.csp_provisioning', current, uniqueEmails.join(','));
 })(current, previous);]]></script>
@@ -66,7 +66,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ca2f55b747e87110ee827d7ba26d43bd</sys_id>
-        <sys_mod_count>94</sys_mod_count>
+        <sys_mod_count>95</sys_mod_count>
         <sys_name>Email Admins Upon Provisioning</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -74,7 +74,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_ca2f55b747e87110ee827d7ba26d43bd</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-09-06 12:52:31</sys_updated_on>
+        <sys_updated_on>2023-09-06 13:02:01</sys_updated_on>
         <template/>
         <when>async_always</when>
     </sys_script>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
@@ -15,7 +15,7 @@
         <condition/>
         <description/>
         <execute_function>false</execute_function>
-        <filter_condition table="x_g_dis_atat_portfolio">portfolio_statusCHANGESTOACTIVE^EQ<item display_value="Active" endquery="false" field="portfolio_status" goto="false" newquery="false" operator="CHANGESTO" or="false" value="ACTIVE"/>
+        <filter_condition table="x_g_dis_atat_portfolio">portfolio_statusCHANGESTOPROCESSING^EQ<item display_value="Processing" endquery="false" field="portfolio_status" goto="false" newquery="false" operator="CHANGESTO" or="false" value="PROCESSING"/>
             <item endquery="true" field="" goto="false" newquery="false" operator="=" or="false" value=""/>
         </filter_condition>
         <is_rest>false</is_rest>
@@ -33,7 +33,7 @@
 
     // portfolio is 'current'; get portfolio sys_id
     const portfolioSysId = current.sys_id;
-
+    gs.info(`portfolioSysId: ${portfolioSysId}`);
     // use portfolio sys_id; retrieve environments for portfolio (using sys_id) that are unclassified
     const environmentGR = new GlideRecord('x_g_dis_atat_environment');
     environmentGR.addQuery('portfolio', portfolioSysId);
@@ -44,15 +44,20 @@
 
     // iterate through environments; extract operator email
     while (environmentGR.next()) {
-        const pendingOperators = environmentGR.pending_operators;
+        const pendingOperators = environmentGR.getValue('pending_operators');
+		gs.info(`pendingOperators: ${pendingOperators}`);
         const operatorGR = new GlideRecord('x_g_dis_atat_operator');
-        operatorGR.get(pendingOperators);
-        operatorEmails.push(operatorGR.email);
+		operatorGR.get(pendingOperators);
+		const email = operatorGR.email;
+		gs.info(`Operator Email: ${email}`);
+		operatorEmails.push(email);
     }
 
-	// remove duplicated emails
-
+    // remove duplicated emails
+    gs.info(`operatorEmails: ${operatorEmails.toString()}`);
     const uniqueEmails = operatorEmails.filter((email, index) => operatorEmails.indexOf(email) === index);
+    gs.info(`uniqueEmails: ${uniqueEmails.toString()}`);
+
     return gs.eventQueue('x_g_dis_atat.csp_provisioning', current, uniqueEmails.join(','));
 })(current, previous);]]></script>
         <sys_class_name>sys_script</sys_class_name>
@@ -61,7 +66,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ca2f55b747e87110ee827d7ba26d43bd</sys_id>
-        <sys_mod_count>67</sys_mod_count>
+        <sys_mod_count>94</sys_mod_count>
         <sys_name>Email Admins Upon Provisioning</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -69,9 +74,9 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_ca2f55b747e87110ee827d7ba26d43bd</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-08-28 21:58:56</sys_updated_on>
+        <sys_updated_on>2023-09-06 12:52:31</sys_updated_on>
         <template/>
-        <when>after</when>
+        <when>async_always</when>
     </sys_script>
     <sys_translated_text action="delete_multiple" query="documentkey=ca2f55b747e87110ee827d7ba26d43bd"/>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
@@ -30,31 +30,29 @@
         <rest_variables/>
         <role_conditions/>
         <script><![CDATA[(function executeRule(current, previous /*null when async*/ ) {
-	
-	// query portfolio for operators
-    const operatorGR = new GlideRecord('x_g_dis_atat_operator');
-    operatorGR.addQuery('portfolio', current.sys_id);
-    operatorGR.query();
 
-    let emails = [];
-	
-    while (operatorGR.next()) {
-        const operatorEnv = operatorGR.environment.sys_id;
-		
-		// retrieve operator's environment
-        const environmentGR = new GlideRecord('x_g_dis_atat_environment');
-        environmentGR.get(operatorEnv);
-		
-		// if environment; check classification level, add email to array if unclassified.
-        if (environmentGR) {
-            const classificationLevel = environmentGR.classification_level.getDisplayValue();
-			if(classificationLevel === 'Unclassified') {
-				emails.push(operatorGR.email);
-			}
-        }
+    // portfolio is 'current'; get portfolio sys_id
+    const portfolioSysId = current.sys_id;
+
+    // use portfolio sys_id; retrieve environments for portfolio (using sys_id) that are unclassified
+    const environmentGR = new GlideRecord('x_g_dis_atat_environment');
+    environmentGR.addQuery('portfolio', portfolioSysId);
+    environmentGR.addQuery('classification_level', 'U');
+    environmentGR.query();
+
+    let operatorEmails = [];
+
+    // iterate through environments; extract operator email
+    while (environmentGR.next()) {
+        const pendingOperators = environmentGR.pending_operators;
+        const operatorGR = new GlideRecord('x_g_dis_atat_operator');
+        operatorGR.get(pendingOperators);
+        operatorEmails.push(operatorGR.email);
     }
 
-    const uniqueEmails = emails.filter((email, index) => emails.indexOf(email) === index);
+	// remove duplicated emails
+
+    const uniqueEmails = operatorEmails.filter((email, index) => operatorEmails.indexOf(email) === index);
     return gs.eventQueue('x_g_dis_atat.csp_provisioning', current, uniqueEmails.join(','));
 })(current, previous);]]></script>
         <sys_class_name>sys_script</sys_class_name>
@@ -63,7 +61,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ca2f55b747e87110ee827d7ba26d43bd</sys_id>
-        <sys_mod_count>49</sys_mod_count>
+        <sys_mod_count>67</sys_mod_count>
         <sys_name>Email Admins Upon Provisioning</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -71,7 +69,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_ca2f55b747e87110ee827d7ba26d43bd</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-08-24 14:55:07</sys_updated_on>
+        <sys_updated_on>2023-08-28 21:58:56</sys_updated_on>
         <template/>
         <when>after</when>
     </sys_script>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_ca2f55b747e87110ee827d7ba26d43bd.xml
@@ -31,10 +31,10 @@
         <role_conditions/>
         <script><![CDATA[(function executeRule(current, previous /*null when async*/ ) {
 
-    // portfolio is 'current'; get portfolio sys_id
+    // 'current' is the updated portfolio
     const portfolioSysId = current.sys_id;
-    //gs.info(`portfolioSysId: ${portfolioSysId}`);
-    // use portfolio sys_id; retrieve environments for portfolio (using sys_id) that are unclassified
+
+    // use portfolio sys_id; retrieve unclassified environments for the portfolio
     const environmentGR = new GlideRecord('x_g_dis_atat_environment');
     environmentGR.addQuery('portfolio', portfolioSysId);
     environmentGR.addQuery('classification_level', 'U');
@@ -42,22 +42,27 @@
 
     let operatorEmails = [];
 
-    // iterate through environments; extract operator email
+    // iterate through environments
     while (environmentGR.next()) {
+		// extract pending operators
         const pendingOperators = environmentGR.getValue('pending_operators');
-		//gs.info(`pendingOperators: ${pendingOperators}`);
+		
+		// query operator table for all operators in pending operators
         const operatorGR = new GlideRecord('x_g_dis_atat_operator');
-		operatorGR.get(pendingOperators);
-		const email = operatorGR.email;
-		//gs.info(`Operator Email: ${email}`);
-		operatorEmails.push(email);
+        operatorGR.addQuery('sys_id', 'IN', pendingOperators);
+		operatorGR.query();
+		
+		// iterate and extract operator email
+        while (operatorGR.next()) {
+            const operatorEmail = operatorGR.getValue('email');
+            operatorEmails.push(operatorEmail);
+        }
     }
 
     // remove duplicated emails
-    //gs.info(`operatorEmails: ${operatorEmails.toString()}`);
     const uniqueEmails = operatorEmails.filter((email, index) => operatorEmails.indexOf(email) === index);
-    //gs.info(`uniqueEmails: ${uniqueEmails.toString()}`);
 
+	// dispatch to queue
     return gs.eventQueue('x_g_dis_atat.csp_provisioning', current, uniqueEmails.join(','));
 })(current, previous);]]></script>
         <sys_class_name>sys_script</sys_class_name>
@@ -66,7 +71,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ca2f55b747e87110ee827d7ba26d43bd</sys_id>
-        <sys_mod_count>95</sys_mod_count>
+        <sys_mod_count>103</sys_mod_count>
         <sys_name>Email Admins Upon Provisioning</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -74,7 +79,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_ca2f55b747e87110ee827d7ba26d43bd</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-09-06 13:02:01</sys_updated_on>
+        <sys_updated_on>2023-09-06 17:18:56</sys_updated_on>
         <template/>
         <when>async_always</when>
     </sys_script>


### PR DESCRIPTION
Also includes AC for [AT-9668](https://ccpo.atlassian.net/browse/AT-9668)

Updated business rule to only send email to operators for unclassified environments; note, this solution is inefficient by **n** queries (n; environment) when it ought to be possible to express this in 1. Investigating GlideRecord's joinQuery() syntax is a stretch goal.

One portfolio, three environments / three operator emails, and finally, one unique email dispatched.
![ApplicationLogs](https://github.com/dod-ccpo/atat-snow/assets/137221342/6c0b835b-a2a2-45bb-bd4d-4c8a47311bc9)
![EmailLogs](https://github.com/dod-ccpo/atat-snow/assets/137221342/9308f3ba-4c63-4be0-b6f7-1cce746ba584)
![Business Rule](https://github.com/dod-ccpo/atat-snow/assets/137221342/7b67d1a1-ee3e-4922-83e3-4b45107f19e3)


[AT-9668]: https://ccpo.atlassian.net/browse/AT-9668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ