### PR TITLE
BUGFIX/AT-9639 - This is minor updates to improve work on this older ticket.

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_56b7c2bf9714311000989fa00153af01.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_56b7c2bf9714311000989fa00153af01.xml
@@ -26,7 +26,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>56b7c2bf9714311000989fa00153af01</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_name>CD: Update UI Files</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -34,7 +34,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_action_type_definition_56b7c2bf9714311000989fa00153af01</sys_update_name>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:30</sys_updated_on>
         <system_level>false</system_level>
         <type/>
     </sys_hub_action_type_definition>
@@ -281,10 +281,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-08-03 21:56:40</sys_created_on>
         <sys_id>abd1a2f79794311000989fa00153af8c</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-07 17:00:45</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:21</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=abd1a2f79794311000989fa00153af8c"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -295,9 +295,9 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-08-03 21:56:40</sys_created_on>
         <sys_id>e3d1a2f79794311000989fa00153af9c</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>6</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-07 17:00:45</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:21</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   var request = new sn_ws.RESTMessageV2();
   var errUtil = new ErrorHandler();
@@ -338,10 +338,13 @@
     response = request.execute();
   } catch (error) {
     errUtil.errorLogger(error);
+    throw error;
   }
 
   if (response.getStatusCode() != 200) {
-    gs.error(response.getErrorMessage())
+    var errorMsg = response.getErrorMessage();
+    gs.error(errorMsg);
+    throw new Error(errorMsg);
   } else {
     var attachmentGR = new GlideRecord('sys_attachment');
     attachmentGR.addQuery('table_name', table_name);
@@ -377,6 +380,18 @@
         <variable display_value="MID Application">f5e56d79b3101300176b051a16a8dce4</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="id=abd1a2f79794311000989fa00153af8c"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>script</field>
+        <id>abd1a2f79794311000989fa00153af8c</id>
+        <sys_created_by>1609291318.CTR</sys_created_by>
+        <sys_created_on>2023-08-31 16:25:21</sys_created_on>
+        <sys_id>f782adb04789f5d093e530ed436d43ed</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-08-31 16:25:21</sys_updated_on>
+        <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
+        <value/>
+    </sys_element_mapping>
     <sys_element_mapping action="INSERT_OR_UPDATE">
         <field>Uri</field>
         <id>abd1a2f79794311000989fa00153af8c</id>
@@ -1227,10 +1242,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-07 15:18:07</sys_created_on>
         <sys_id>f80d6d8d4724f19093e530ed436d431b</sys_id>
-        <sys_mod_count>44</sys_mod_count>
+        <sys_mod_count>45</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:03</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:06</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=f80d6d8d4724f19093e530ed436d431b"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -1269,9 +1284,9 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-07 15:18:07</sys_created_on>
         <sys_id>b80d6d8d4724f19093e530ed436d4323</sys_id>
-        <sys_mod_count>41</sys_mod_count>
+        <sys_mod_count>42</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:03</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:06</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   var sbom;
   var att_root = new GlideSysAttachment();
@@ -1328,7 +1343,7 @@
         var final_content = '';
         while((line = reader.readLine()) != null) {
           var new_line_content = line.replaceAll(placeholder_text,base_url);
-          new_line_content = new_line_content.replace("}).VUE_APP_allowDeveloperNavigation===\"true\"||false", ",VUE_APP_allowDeveloperNavigation:\"" + inputs.enable_buttons + "\"}).VUE_APP_allowDeveloperNavigation===\"true\"||false");
+          new_line_content = new_line_content.replace("}.VUE_APP_allowDeveloperNavigation===\"true\"||false", ",VUE_APP_allowDeveloperNavigation:\"" + inputs.enable_buttons + "\"}.VUE_APP_allowDeveloperNavigation===\"true\"||false");
           
           final_content += new_line_content;
         }
@@ -1371,11 +1386,11 @@
         <field>script</field>
         <id>f80d6d8d4724f19093e530ed436d431b</id>
         <sys_created_by>1609291318.CTR</sys_created_by>
-        <sys_created_on>2023-08-22 19:58:03</sys_created_on>
-        <sys_id>97ecf37d47bcf950f6b8f0bd436d43fc</sys_id>
+        <sys_created_on>2023-08-31 16:12:06</sys_created_on>
+        <sys_id>918f51b44749f5d093e530ed436d43ab</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:03</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:06</sys_updated_on>
         <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
         <value/>
     </sys_element_mapping>
@@ -2020,17 +2035,17 @@
     <sys_hub_action_plan action="INSERT_OR_UPDATE">
         <action_id display_value="CD: Update UI Files">56b7c2bf9714311000989fa00153af01</action_id>
         <plan>{"persistor":{"@class":".ChunkingPlanPersistor","table":"sys_hub_action_plan","id":"5b1adf049764311000989fa00153af20","name":"plan","plan_signature":null}}</plan>
-        <snapshot>69fcf77d47bcf950f6b8f0bd436d4305</snapshot>
+        <snapshot>bd92a1f04789f5d093e530ed436d430f</snapshot>
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-08-04 20:40:52</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>5b1adf049764311000989fa00153af20</sys_id>
-        <sys_mod_count>19</sys_mod_count>
+        <sys_mod_count>21</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:14</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:32</sys_updated_on>
     </sys_hub_action_plan>
     <sys_hub_action_type_snapshot action="INSERT_OR_UPDATE">
         <access>public</access>
@@ -2117,10 +2132,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-08-04 20:40:51</sys_created_on>
         <sys_id>031a9f049764311000989fa00153af9c</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-07 19:26:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:30</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=031a9f049764311000989fa00153af9c"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -2131,9 +2146,9 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-08-04 20:40:51</sys_created_on>
         <sys_id>4f1a9f049764311000989fa00153afab</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-07 19:26:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:30</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   var request = new sn_ws.RESTMessageV2();
   var errUtil = new ErrorHandler();
@@ -2174,10 +2189,13 @@
     response = request.execute();
   } catch (error) {
     errUtil.errorLogger(error);
+    throw error;
   }
 
   if (response.getStatusCode() != 200) {
-    gs.error(response.getErrorMessage())
+    var errorMsg = response.getErrorMessage();
+    gs.error(errorMsg);
+    throw new Error(errorMsg);
   } else {
     var attachmentGR = new GlideRecord('sys_attachment');
     attachmentGR.addQuery('table_name', table_name);
@@ -2213,6 +2231,18 @@
         <variable display_value="MID Application">f5e56d79b3101300176b051a16a8dce4</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="id=031a9f049764311000989fa00153af9c"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>script</field>
+        <id>031a9f049764311000989fa00153af9c</id>
+        <sys_created_by>1609291318.CTR</sys_created_by>
+        <sys_created_on>2023-08-31 16:25:30</sys_created_on>
+        <sys_id>699261f04789f5d093e530ed436d43d3</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-08-31 16:25:30</sys_updated_on>
+        <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
+        <value/>
+    </sys_element_mapping>
     <sys_element_mapping action="INSERT_OR_UPDATE">
         <field>Uri</field>
         <id>031a9f049764311000989fa00153af9c</id>
@@ -2768,10 +2798,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-07 19:26:12</sys_created_on>
         <sys_id>76c52a41476cf19093e530ed436d43b6</sys_id>
-        <sys_mod_count>18</sys_mod_count>
+        <sys_mod_count>19</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:13</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=76c52a41476cf19093e530ed436d43b6"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -2782,9 +2812,9 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-07 19:26:12</sys_created_on>
         <sys_id>32c52a41476cf19093e530ed436d43c2</sys_id>
-        <sys_mod_count>15</sys_mod_count>
+        <sys_mod_count>16</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:13</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   var sbom;
   var att_root = new GlideSysAttachment();
@@ -2841,7 +2871,7 @@
         var final_content = '';
         while((line = reader.readLine()) != null) {
           var new_line_content = line.replaceAll(placeholder_text,base_url);
-          new_line_content = new_line_content.replace("}).VUE_APP_allowDeveloperNavigation===\"true\"||false", ",VUE_APP_allowDeveloperNavigation:\"" + inputs.enable_buttons + "\"}).VUE_APP_allowDeveloperNavigation===\"true\"||false");
+          new_line_content = new_line_content.replace("}.VUE_APP_allowDeveloperNavigation===\"true\"||false", ",VUE_APP_allowDeveloperNavigation:\"" + inputs.enable_buttons + "\"}.VUE_APP_allowDeveloperNavigation===\"true\"||false");
           
           final_content += new_line_content;
         }
@@ -2912,11 +2942,11 @@
         <field>script</field>
         <id>76c52a41476cf19093e530ed436d43b6</id>
         <sys_created_by>1609291318.CTR</sys_created_by>
-        <sys_created_on>2023-08-22 19:58:12</sys_created_on>
-        <sys_id>edfcb77d47bcf950f6b8f0bd436d43f5</sys_id>
+        <sys_created_on>2023-08-31 16:12:13</sys_created_on>
+        <sys_id>5f8f15b44749f5d093e530ed436d43b4</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:12:13</sys_updated_on>
         <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
         <value/>
     </sys_element_mapping>
@@ -3935,7 +3965,7 @@
         <sys_updated_by>xander.keele</sys_updated_by>
         <sys_updated_on>2023-08-04 20:40:51</sys_updated_on>
     </sys_hub_action_status_metadata>
-    <sys_hub_status_condition action="delete_multiple" query="action_status_metadata_id=4b1a9f049764311000989fa00153afbd^sys_idNOT IN29fcf77d47bcf950f6b8f0bd436d4304"/>
+    <sys_hub_status_condition action="delete_multiple" query="action_status_metadata_id=4b1a9f049764311000989fa00153afbd^sys_idNOT IN7192a1f04789f5d093e530ed436d430f"/>
     <sys_hub_status_condition action="INSERT_OR_UPDATE">
         <action_status_metadata_id display_value="Created 08/04/2023 13:40:51">4b1a9f049764311000989fa00153afbd</action_status_metadata_id>
         <condition>{{step[c1d4f7fe-7803-4b24-bad6-dc5c3cbdd74e].status}}=1</condition>
@@ -3944,11 +3974,11 @@
         <order>1</order>
         <status>{"version":"1.0","complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":"1"}},"message":{"$cv":{"$c":"java.lang.String","$v":"Sbom.txt file not present in the downloaded contents."}}},"complexObjectSchema":{"FlowDesigner:FDACTIONSTATUS":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FDACTIONSTATUS.$type_facets":{"SimpleMapFacet":"{\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"7b5524a5-32ae-4f96-b641-560110173141\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FDACTIONSTATUS\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"hint\":null,\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"serializationFormat":"JSON"}</status>
         <sys_created_by>1609291318.CTR</sys_created_by>
-        <sys_created_on>2023-08-22 19:58:12</sys_created_on>
-        <sys_id>29fcf77d47bcf950f6b8f0bd436d4304</sys_id>
+        <sys_created_on>2023-08-31 16:25:30</sys_created_on>
+        <sys_id>7192a1f04789f5d093e530ed436d430f</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-22 19:58:12</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:25:30</sys_updated_on>
     </sys_hub_status_condition>
     <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_action_input_fe1a9f049764311000989fa00153af92^sys_idNOT IN0ebcad2d47f07d5093e530ed436d4344,c31a9f049764311000989fa00153af9a"/>
     <sys_documentation action="INSERT_OR_UPDATE">

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_b29e540447f47d1093e530ed436d43cd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_b29e540447f47d1093e530ed436d43cd.xml
@@ -10,15 +10,15 @@
         <copied_from_name/>
         <description>Deploys the latest UI elements from the Develop branch.</description>
         <internal_name>cd_deploy_from_develop</internal_name>
-        <label_cache>[{"name":"18e6b0bf-e6b1-4f83-963c-b0441acc34ee.response_body","label":"1 - UTIL: Make A Request➛Response Body","reference_display":"Response Body","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"2fb6c3e4-4afd-407e-bb3e-48344dc446fc"}},{"name":"a2ec4643-d756-416d-b3e1-8eca4c745884.record_url","label":"2 - UTIL: Parse Latest Artifact JSON➛Record URL","reference_display":"Record URL","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"6850bd73-e1bc-42b6-b17c-29233f42b25d"}}]</label_cache>
+        <label_cache>[{"name":"a2ec4643-d756-416d-b3e1-8eca4c745884.record_url","label":"2 - UTIL: Parse Latest Artifact JSON➛Record URL","reference_display":"Record URL","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"6850bd73-e1bc-42b6-b17c-29233f42b25d"}},{"name":"18e6b0bf-e6b1-4f83-963c-b0441acc34ee.response_body","label":"1 - UTIL: Make A Request➛Response Body","reference_display":"Response Body","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"2fb6c3e4-4afd-407e-bb3e-48344dc446fc"}}]</label_cache>
         <master_snapshot>56cbe9a547f07d5093e530ed436d4377</master_snapshot>
         <name>CD: Deploy from Develop</name>
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
         <remote_trigger_id/>
-        <run_as>system</run_as>
-        <run_with_roles/>
+        <run_as>user</run_as>
+        <run_with_roles name="web_service_admin">8ced49cb0a0a0b8f00bd2ecf512c510b</run_with_roles>
         <sc_callable>false</sc_callable>
         <show_draft_actions>false</show_draft_actions>
         <show_triggered_flows>false</show_triggered_flows>
@@ -29,7 +29,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>b29e540447f47d1093e530ed436d43cd</sys_id>
-        <sys_mod_count>11</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_name>CD: Deploy from Develop</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -37,7 +37,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_b29e540447f47d1093e530ed436d43cd</sys_update_name>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:22</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:17</sys_updated_on>
         <type>subflow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=b29e540447f47d1093e530ed436d43cd"/>
@@ -74,10 +74,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-16 17:23:12</sys_created_on>
         <sys_id>3cff5c8847787d1093e530ed436d43de</sys_id>
-        <sys_mod_count>22</sys_mod_count>
+        <sys_mod_count>26</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:22</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:17</sys_updated_on>
         <ui_id>18e6b0bf-e6b1-4f83-963c-b0441acc34ee</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=3cff5c8847787d1093e530ed436d43de"/>
@@ -196,10 +196,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-16 18:37:18</sys_created_on>
         <sys_id>86e0bc004730fd1093e530ed436d43aa</sys_id>
-        <sys_mod_count>14</sys_mod_count>
+        <sys_mod_count>18</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:22</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:17</sys_updated_on>
         <ui_id>57095dd7-038e-4fae-91ed-1fdd690d4cda</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=86e0bc004730fd1093e530ed436d43aa"/>
@@ -258,10 +258,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-16 18:31:47</sys_created_on>
         <sys_id>d5afe44447bcbd1093e530ed436d433b</sys_id>
-        <sys_mod_count>18</sys_mod_count>
+        <sys_mod_count>22</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:22</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:17</sys_updated_on>
         <ui_id>a2ec4643-d756-416d-b3e1-8eca4c745884</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=d5afe44447bcbd1093e530ed436d433b"/>
@@ -291,7 +291,7 @@
     <sys_flow_trigger_plan action="delete_multiple" query="plan_id=b29e540447f47d1093e530ed436d43cd"/>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=b29e540447f47d1093e530ed436d43cd^sys_idNOT IN3ecb2da547f07d5093e530ed436d43b4"/>
     <sys_flow_subflow_plan action="INSERT_OR_UPDATE">
-        <plan>com.snc.process_flow.engine.ProcessPlan@1cbf882</plan>
+        <plan>com.snc.process_flow.engine.ProcessPlan@1daeb1c</plan>
         <plan_id display_value="CD: Deploy from Develop">b29e540447f47d1093e530ed436d43cd</plan_id>
         <snapshot>56cbe9a547f07d5093e530ed436d4377</snapshot>
         <sys_created_by>1609291318.CTR</sys_created_by>
@@ -299,11 +299,11 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>3ecb2da547f07d5093e530ed436d43b4</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:22</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:17</sys_updated_on>
     </sys_flow_subflow_plan>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
         <access>public</access>
@@ -316,15 +316,15 @@
         <copied_from_name/>
         <description>Deploys the latest UI elements from the Develop branch.</description>
         <internal_name>cd_deploy_from_develop</internal_name>
-        <label_cache>[{"name":"18e6b0bf-e6b1-4f83-963c-b0441acc34ee.response_body","label":"1 - UTIL: Make A Request➛Response Body","reference_display":"Response Body","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"2fb6c3e4-4afd-407e-bb3e-48344dc446fc"}},{"name":"a2ec4643-d756-416d-b3e1-8eca4c745884.record_url","label":"2 - UTIL: Parse Latest Artifact JSON➛Record URL","reference_display":"Record URL","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"6850bd73-e1bc-42b6-b17c-29233f42b25d"}}]</label_cache>
+        <label_cache>[{"name":"a2ec4643-d756-416d-b3e1-8eca4c745884.record_url","label":"2 - UTIL: Parse Latest Artifact JSON➛Record URL","reference_display":"Record URL","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"6850bd73-e1bc-42b6-b17c-29233f42b25d"}},{"name":"18e6b0bf-e6b1-4f83-963c-b0441acc34ee.response_body","label":"1 - UTIL: Make A Request➛Response Body","reference_display":"Response Body","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"2fb6c3e4-4afd-407e-bb3e-48344dc446fc"}}]</label_cache>
         <master>true</master>
         <name>CD: Deploy from Develop</name>
         <natlang/>
         <outputs/>
         <parent_flow display_value="CD: Deploy from Develop">b29e540447f47d1093e530ed436d43cd</parent_flow>
         <remote_trigger_id/>
-        <run_as>system</run_as>
-        <run_with_roles/>
+        <run_as>user</run_as>
+        <run_with_roles name="web_service_admin">8ced49cb0a0a0b8f00bd2ecf512c510b</run_with_roles>
         <sc_callable>false</sc_callable>
         <status>published</status>
         <sys_class_name>sys_hub_flow_snapshot</sys_class_name>
@@ -333,7 +333,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>56cbe9a547f07d5093e530ed436d4377</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
@@ -341,7 +341,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:20</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:16</sys_updated_on>
         <type>subflow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=56cbe9a547f07d5093e530ed436d4377"/>
@@ -378,10 +378,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-21 14:45:26</sys_created_on>
         <sys_id>12cbe9a547f07d5093e530ed436d4391</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:20</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:16</sys_updated_on>
         <ui_id>18e6b0bf-e6b1-4f83-963c-b0441acc34ee</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=12cbe9a547f07d5093e530ed436d4391"/>
@@ -500,10 +500,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-21 14:45:26</sys_created_on>
         <sys_id>2ecbe9a547f07d5093e530ed436d43a8</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:20</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:16</sys_updated_on>
         <ui_id>a2ec4643-d756-416d-b3e1-8eca4c745884</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=2ecbe9a547f07d5093e530ed436d43a8"/>
@@ -536,10 +536,10 @@
         <sys_created_by>1609291318.CTR</sys_created_by>
         <sys_created_on>2023-08-21 14:45:26</sys_created_on>
         <sys_id>eacbe9a547f07d5093e530ed436d43cb</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-21 14:50:20</sys_updated_on>
+        <sys_updated_on>2023-08-31 16:10:16</sys_updated_on>
         <ui_id>57095dd7-038e-4fae-91ed-1fdd690d4cda</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=eacbe9a547f07d5093e530ed436d43cb"/>


### PR DESCRIPTION
Updated permissions requirements and added handling for failed call to GitHub for `CD: Deploy from Develop`

Updated security permissions for `CD: Deploy from Develop`
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/13f8e30b-6421-4fbe-bd20-1c311da1aafa)

And same permission in `CD: Deploy From Release`
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/a5cfc26b-097b-45ee-bcb3-3d93b72ae79d)

Additionally, fixed the text used to replace for the DevButtons. Suspect it was changed with the Node18 upgrade:
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/8aa75c2d-6704-475f-a772-b9d5aa42ec26)

DIFF:
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/0a68ea9e-65e3-4453-b7aa-2b03c86d89ce)

Added code to throw an exception on a failed request to GitHub:
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/e180be8c-b426-4720-bb9a-0e4151fd65fd)
