### PR TITLE
AT-9691: Create Flow to invoke HOTH API TO update operation

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_portfolio.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_portfolio.xml
@@ -7,6 +7,7 @@
         <element label="CSP ID" max_length="2000" name="csp_id" type="string"/>
         <element label="Description" max_length="4000" name="description" type="string"/>
         <element label="Is_Archived" max_length="40" name="is_archived" type="boolean"/>
+        <element label="Last Cost Data Sync" max_length="40" name="last_cost_data_sync" type="glide_date_time"/>
         <element label="Last Updated" max_length="40" name="last_updated" type="glide_date_time"/>
         <element display="true" label="Name" max_length="60" name="name" type="string"/>
         <element active="false" label="Pending Operators" max_length="4000" name="operators" reference="x_g_dis_atat_operator" type="glide_list"/>
@@ -21,7 +22,7 @@
         </element>
         <element label="Portfolio Managers" max_length="4000" name="portfolio_managers" reference="sys_user" type="glide_list"/>
         <element label="Portfolio Owner" max_length="32" name="portfolio_owner" reference="sys_user" type="reference"/>
-        <element calculation="(function calculatedFieldValue(current) {&#13;&#10;&#9;const sysId = current.sys_id;&#13;&#10;    const PORTFOLIO_TABLE = &quot;x_g_dis_atat_portfolio&quot;;&#13;&#10;    let gr = new GlideRecord(PORTFOLIO_TABLE);&#13;&#10;    gr.get(sysId);&#13;&#10;    if (gr.isValidRecord()) {&#13;&#10;&#9;&#9;const ps = new PortfolioService(gr);&#13;&#10;        const status = ps.determineStatus(gr);&#13;&#10;        return status;&#13;&#10;    }&#13;&#10;&#13;&#10;})(current);" choice="1" label="Portfolio Status" max_length="40" name="portfolio_status" type="choice" virtual="true">
+        <element calculation="(function calculatedFieldValue(current) {&#10;&#9;const sysId = current.sys_id;&#10;    const PORTFOLIO_TABLE = &quot;x_g_dis_atat_portfolio&quot;;&#10;    let gr = new GlideRecord(PORTFOLIO_TABLE);&#10;    gr.get(sysId);&#10;    if (gr.isValidRecord()) {&#10;&#9;&#9;const ps = new PortfolioService(gr);&#10;        const status = ps.determineStatus(gr);&#10;        return status;&#10;    }&#10;&#10;})(current);" choice="1" label="Portfolio Status" max_length="40" name="portfolio_status" type="choice" virtual="true">
             <choice>
                 <element inactive_on_update="false" label="Processing" sequence="1" value="PROCESSING"/>
                 <element inactive_on_update="false" label="Provisioning Issue" sequence="2" value="PROVISIONING_ISSUE"/>
@@ -49,13 +50,13 @@
             <element name="active_task_order"/>
         </index>
         <index name="index3">
-            <element name="agency"/>
+            <element name="portfolio_owner"/>
         </index>
         <index name="index4">
             <element name="csp"/>
         </index>
         <index name="index5">
-            <element name="portfolio_owner"/>
+            <element name="agency"/>
         </index>
     </element>
 </database>

--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_task_order.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_task_order.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><database>
-    <element db_object_id="522b05789780311084aaf8a6f053af89" label="ATAT:Task Order" max_length="40" name="x_g_dis_atat_task_order" type="collection">
+    <element db_object_id="fac6c8119790311000989fa00153af6a" label="ATAT:Task Order" max_length="40" name="x_g_dis_atat_task_order" type="collection">
         <element active="false" label="Acquisition Package" max_length="32" name="acquisition_package" reference="x_g_dis_atat_acquisition_package" type="reference"/>
         <element label="CLINs" max_length="4000" name="clins" reference="x_g_dis_atat_clin" type="glide_list"/>
         <element label="CSP ID" max_length="2000" name="csp_id" type="string"/>
@@ -17,6 +17,8 @@
         <element label="PoP End Date" max_length="40" name="pop_end_date" type="glide_date"/>
         <element label="PoP Start Date" max_length="40" name="pop_start_date" type="glide_date"/>
         <element label="Portfolio" max_length="32" name="portfolio" reference="x_g_dis_atat_portfolio" type="reference"/>
+        <element default="False" label="Provisioned" max_length="40" name="provisioned" type="boolean"/>
+        <element label="Provisioned Date" max_length="40" name="provisioned_date" type="glide_date_time"/>
         <element display="true" label="Task Order Number" mandatory="true" max_length="40" name="task_order_number" type="string"/>
         <element calculation="(function calculatedFieldValue(current) {&#10;&#9;const sysId = current.sys_id;&#10;    const TO_TABLE = &quot;x_g_dis_atat_task_order&quot;;&#10;    const gr = new GlideRecord(TO_TABLE);&#10;    gr.get(sysId);&#10;&#9;if(gr.isValidRecord()){ &#10;        const tos = new TaskOrderService(gr);&#10;&#9;&#9;const payload = tos.determineStatus(gr);&#10;        return payload;&#10;&#9;}&#10;})(current);" choice="1" label="Task Order Status" max_length="40" name="task_order_status" type="choice" virtual="true">
             <choice>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_last_cost_data_sync.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_portfolio_last_cost_data_sync.xml
@@ -21,7 +21,7 @@
         <delete_roles/>
         <dependent/>
         <dependent_on_field/>
-        <display>true</display>
+        <display>false</display>
         <dynamic_creation>false</dynamic_creation>
         <dynamic_creation_script/>
         <dynamic_default_value/>
@@ -57,8 +57,8 @@
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_portfolio_last_cost_data_sync</sys_update_name>
-        <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-08-22 15:34:30</sys_updated_on>
+        <sys_updated_by>1370228783.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 02:26:29</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_task_order_provisioned.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_task_order_provisioned.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="provisioned" table="x_g_dis_atat_task_order">
+        <active>true</active>
+        <array>false</array>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Provisioned</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value>False</default_value>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>provisioned</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="">boolean</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>40</max_length>
+        <name>x_g_dis_atat_task_order</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:35:53</sys_created_on>
+        <sys_name>Provisioned</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_task_order_provisioned</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:35:53</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_task_order_provisioned_date.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_task_order_provisioned_date.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="provisioned_date" table="x_g_dis_atat_task_order">
+        <active>true</active>
+        <array>false</array>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label>Provisioned Date</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>provisioned_date</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="">glide_date_time</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>40</max_length>
+        <name>x_g_dis_atat_task_order</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:36:45</sys_created_on>
+        <sys_name>Provisioned Date</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_task_order_provisioned_date</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:36:45</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_task_order_provisioned_date_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_task_order_provisioned_date_en.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="provisioned_date" label="Provisioned Date" language="en" table="x_g_dis_atat_task_order">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>provisioned_date</element>
+            <help/>
+            <hint/>
+            <label>Provisioned Date</label>
+            <language>en</language>
+            <name>x_g_dis_atat_task_order</name>
+            <plural>Provisioned Dates</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>admin</sys_created_by>
+            <sys_created_on>2023-09-06 16:36:45</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Provisioned Date</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_task_order_provisioned_date_en</sys_update_name>
+            <sys_updated_by>admin</sys_updated_by>
+            <sys_updated_on>2023-09-06 16:36:45</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_task_order_provisioned_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_task_order_provisioned_en.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="provisioned" label="Provisioned" language="en" table="x_g_dis_atat_task_order">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>provisioned</element>
+            <help/>
+            <hint/>
+            <label>Provisioned</label>
+            <language>en</language>
+            <name>x_g_dis_atat_task_order</name>
+            <plural>Provisioned</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>admin</sys_created_by>
+            <sys_created_on>2023-09-06 16:35:53</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>Provisioned</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_task_order_provisioned_en</sys_update_name>
+            <sys_updated_by>admin</sys_updated_by>
+            <sys_updated_on>2023-09-06 16:35:53</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941.xml
@@ -26,15 +26,15 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>3d1b2accdb9b51908c045e8cd3961941</sys_id>
-        <sys_mod_count>30</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name>PROV: Consume Queue Payload</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941</sys_update_name>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:58:21</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
         <system_level>false</system_level>
         <type/>
     </sys_hub_action_type_definition>
@@ -48,10 +48,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:13:03</sys_created_on>
         <sys_id>4551f64cdbdb51908c045e8cd396194c</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2022-11-16 18:27:43</sys_updated_on>
-        <value>{"version":"1.0","complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"complexObjectSchema":{"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923.$type_facets":{"SimpleMapFacet":"{\"sourceId\":\"\",\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FD0551f64c30db51905fc7dec1d3a09923\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"sourceUiUniqueId\":\"\",\"sourceType\":\"\",\"hint\":\"\",\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"serializationFormat":"JSON"}</value>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
+        <value>{"version":"1.0","complexObjectSchema":{"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923.$type_facets":{"SimpleMapFacet":"{\"sourceId\":\"\",\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FD0551f64c30db51905fc7dec1d3a09923\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"sourceUiUniqueId\":\"\",\"sourceType\":\"\",\"hint\":\"\",\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"serializationFormat":"JSON"}</value>
         <variable display_value="Action Status">4551f64cdbdb51908c045e8cd3961926</variable>
     </sys_variable_value>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -127,10 +127,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:00:20</sys_created_on>
         <sys_id>be6eea08dbdb51908c045e8cd3961916</sys_id>
-        <sys_mod_count>35</sys_mod_count>
+        <sys_mod_count>36</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:57:41</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=be6eea08dbdb51908c045e8cd3961916"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -141,9 +141,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:00:20</sys_created_on>
         <sys_id>766eea08dbdb51908c045e8cd396192b</sys_id>
-        <sys_mod_count>34</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:57:41</sys_updated_on>
+        <sys_mod_count>35</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   inputs.payload = JSON.parse(inputs.payload);
   outputs.num_events = inputs.payload.length;
@@ -238,7 +238,19 @@
           }
           environmentRecord.update();     
         }
+		else if (operationType === "UPDATE_TASK_ORDER") {
+        
+          if (event.code === 200) {
+            jobRecord.status = "SUCCESS";
+            jobRecord.update();
+            outputs.num_updates++;
+            var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
+            taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
 
+            taskOrderRecord.provisioned = true;
+            taskOrderRecord.provisioned_date = now;
+            taskOrderRecord.update();     
+          }
         // TODO: add support for dashboard_link    
       }
       else {
@@ -286,12 +298,12 @@
     <sys_element_mapping action="INSERT_OR_UPDATE">
         <field>script</field>
         <id>be6eea08dbdb51908c045e8cd3961916</id>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2023-03-17 18:34:30</sys_created_on>
-        <sys_id>939e7dcbdbeda514b1227ea5f39619ee</sys_id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:53:36</sys_created_on>
+        <sys_id>4092e4fe9701311000989fa00153af2c</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-17 18:34:30</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
         <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
         <value/>
     </sys_element_mapping>
@@ -945,17 +957,17 @@
     <sys_hub_action_plan action="INSERT_OR_UPDATE">
         <action_id display_value="PROV: Consume Queue Payload">3d1b2accdb9b51908c045e8cd3961941</action_id>
         <plan>{"persistor":{"@class":".ChunkingPlanPersistor","table":"sys_hub_action_plan","id":"36488b44db9f51908c045e8cd3961969","name":"plan","plan_signature":null}}</plan>
-        <snapshot>079d304ddbb9e1108c045e8cd396192b</snapshot>
+        <snapshot>ed9228fe9701311000989fa00153af74</snapshot>
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:23</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>36488b44db9f51908c045e8cd3961969</sys_id>
-        <sys_mod_count>8</sys_mod_count>
+        <sys_mod_count>9</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:58:22</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:44</sys_updated_on>
     </sys_hub_action_plan>
     <sys_hub_action_type_snapshot action="INSERT_OR_UPDATE">
         <access>public</access>
@@ -1017,10 +1029,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:22</sys_created_on>
         <sys_id>ea488b44db9f51908c045e8cd3961920</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2022-11-16 19:53:22</sys_updated_on>
-        <value>{"version":"1.0","complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"complexObjectSchema":{"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05.$type_facets":{"SimpleMapFacet":"{\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FDe6488b44cf9f51904cdd73311d9d1c05\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"hint\":null,\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"serializationFormat":"JSON"}</value>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
+        <value>{"version":"1.0","complexObjectSchema":{"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05.$type_facets":{"SimpleMapFacet":"{\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FDe6488b44cf9f51904cdd73311d9d1c05\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"hint\":null,\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"serializationFormat":"JSON"}</value>
         <variable display_value="Action Status">66488b44db9f51908c045e8cd3961908</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_action_output_96484b44db9f51908c045e8cd39619d8^id=96484b44db9f51908c045e8cd39619d8"/>
@@ -1082,10 +1094,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:21</sys_created_on>
         <sys_id>da484b44db9f51908c045e8cd39619f2</sys_id>
-        <sys_mod_count>9</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:58:21</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=da484b44db9f51908c045e8cd39619f2"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -1096,9 +1108,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:21</sys_created_on>
         <sys_id>a6488b44db9f51908c045e8cd3961902</sys_id>
-        <sys_mod_count>8</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-23 18:58:21</sys_updated_on>
+        <sys_mod_count>9</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   inputs.payload = JSON.parse(inputs.payload);
   outputs.num_events = inputs.payload.length;
@@ -1193,7 +1205,19 @@
           }
           environmentRecord.update();     
         }
+		else if (operationType === "UPDATE_TASK_ORDER") {
+        
+          if (event.code === 200) {
+            jobRecord.status = "SUCCESS";
+            jobRecord.update();
+            outputs.num_updates++;
+            var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
+            taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
 
+            taskOrderRecord.provisioned = true;
+            taskOrderRecord.provisioned_date = now;
+            taskOrderRecord.update();     
+          }
         // TODO: add support for dashboard_link    
       }
       else {
@@ -1241,12 +1265,12 @@
     <sys_element_mapping action="INSERT_OR_UPDATE">
         <field>script</field>
         <id>da484b44db9f51908c045e8cd39619f2</id>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2023-03-17 20:01:11</sys_created_on>
-        <sys_id>b0725203dba1e514b1227ea5f39619c1</sys_id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:53:43</sys_created_on>
+        <sys_id>259228fe9701311000989fa00153af67</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-17 20:01:11</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
         <table>var__m_sys_flow_step_definition_input_106afb6647032200b4fad7527c9a71e7</table>
         <value/>
     </sys_element_mapping>
@@ -1899,6 +1923,6 @@
     <sys_hub_action_type_definition action="UPDATE">
         <sys_id>3d1b2accdb9b51908c045e8cd3961941</sys_id>
         <latest_snapshot>96484b44db9f51908c045e8cd39619d8</latest_snapshot>
-        <compiler_build>glide-tokyo-07-08-2022__patch6-hotfix1-02-01-2023_02-02-2023_0949.zip</compiler_build>
+        <compiler_build>glide-tokyo-07-08-2022__patch9-hotfix2-06-07-2023_06-23-2023_1740.zip</compiler_build>
     </sys_hub_action_type_definition>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941.xml
@@ -26,15 +26,15 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>3d1b2accdb9b51908c045e8cd3961941</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_name>PROV: Consume Queue Payload</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_action_type_definition_3d1b2accdb9b51908c045e8cd3961941</sys_update_name>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:07</sys_updated_on>
         <system_level>false</system_level>
         <type/>
     </sys_hub_action_type_definition>
@@ -48,10 +48,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:13:03</sys_created_on>
         <sys_id>4551f64cdbdb51908c045e8cd396194c</sys_id>
-        <sys_mod_count>2</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
-        <value>{"version":"1.0","complexObjectSchema":{"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923.$type_facets":{"SimpleMapFacet":"{\"sourceId\":\"\",\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FD0551f64c30db51905fc7dec1d3a09923\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"sourceUiUniqueId\":\"\",\"sourceType\":\"\",\"hint\":\"\",\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"serializationFormat":"JSON"}</value>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:01</sys_updated_on>
+        <value>{"version":"1.0","complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"complexObjectSchema":{"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FD0551f64c30db51905fc7dec1d3a09923.$type_facets":{"SimpleMapFacet":"{\"sourceId\":\"\",\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FD0551f64c30db51905fc7dec1d3a09923\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"sourceUiUniqueId\":\"\",\"sourceType\":\"\",\"hint\":\"\",\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"serializationFormat":"JSON"}</value>
         <variable display_value="Action Status">4551f64cdbdb51908c045e8cd3961926</variable>
     </sys_variable_value>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -127,10 +127,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:00:20</sys_created_on>
         <sys_id>be6eea08dbdb51908c045e8cd3961916</sys_id>
-        <sys_mod_count>36</sys_mod_count>
+        <sys_mod_count>37</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:01</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=be6eea08dbdb51908c045e8cd3961916"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -141,9 +141,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 18:00:20</sys_created_on>
         <sys_id>766eea08dbdb51908c045e8cd396192b</sys_id>
-        <sys_mod_count>35</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:36</sys_updated_on>
+        <sys_mod_count>36</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:01</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   inputs.payload = JSON.parse(inputs.payload);
   outputs.num_events = inputs.payload.length;
@@ -212,16 +212,14 @@
             newEnvironmentJobRecord.insert();
           }
         }
-      }
-      else if (operationType === "ADD_ENVIRONMENT") {
-        
+      } else if (operationType === "ADD_ENVIRONMENT") {
         if (event.code === 200) {
           jobRecord.status = "SUCCESS";
           jobRecord.update();
           outputs.num_updates++;
           var environmentRecord = new GlideRecord("x_g_dis_atat_environment");
           environmentRecord.get(jobRecord.environment.sys_id.toString());
-          
+
           // Handle GetProvisioningStatus response (after async process complete)
           if (response.status) {
             environmentRecord.csp_id = response.status.environmentId;                         
@@ -238,33 +236,30 @@
           }
           environmentRecord.update();     
         }
-		else if (operationType === "UPDATE_TASK_ORDER") {
-        
-          if (event.code === 200) {
-            jobRecord.status = "SUCCESS";
-            jobRecord.update();
-            outputs.num_updates++;
-            var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
-            taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
+        else {
+          throw new ErrorHandler().createError(
+            "Operation Type '" + operationType + "' is not supported.",
+            new ErrorHandler().METHOD_ERROR
+          );    
+        }
+      } else if (operationType === "UPDATE_TASK_ORDER") {
+        if (event.code === 200) {
+          jobRecord.status = "SUCCESS";
+          jobRecord.update();
+          outputs.num_updates++;
+          var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
+          taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
 
-            taskOrderRecord.provisioned = true;
-            taskOrderRecord.provisioned_date = now;
-            taskOrderRecord.update();     
-          }
-        // TODO: add support for dashboard_link    
+          taskOrderRecord.provisioned = true;
+          taskOrderRecord.provisioned_date = now;
+          taskOrderRecord.update();     
+        }
+      } else {
+        gs.error("Could not find a Provisioning Job record with HOTH Job ID " + snowJobId);
       }
-      else {
-        throw new ErrorHandler().createError(
-          "Operation Type '" + operationType + "' is not supported.",
-          new ErrorHandler().METHOD_ERROR
-        );    
-      }
-    } else {
-      gs.error("Could not find a Provisioning Job record with HOTH Job ID " + snowJobId);
-    }
 
-  });
-})(inputs, outputs);
+    });
+  })(inputs, outputs);
 </value>
         <variable display_value="Script">71aa7f6647032200b4fad7527c9a719b</variable>
     </sys_variable_value>
@@ -957,17 +952,17 @@
     <sys_hub_action_plan action="INSERT_OR_UPDATE">
         <action_id display_value="PROV: Consume Queue Payload">3d1b2accdb9b51908c045e8cd3961941</action_id>
         <plan>{"persistor":{"@class":".ChunkingPlanPersistor","table":"sys_hub_action_plan","id":"36488b44db9f51908c045e8cd3961969","name":"plan","plan_signature":null}}</plan>
-        <snapshot>ed9228fe9701311000989fa00153af74</snapshot>
+        <snapshot>e7a062c79741311000989fa00153affd</snapshot>
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:23</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>36488b44db9f51908c045e8cd3961969</sys_id>
-        <sys_mod_count>9</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:44</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:08</sys_updated_on>
     </sys_hub_action_plan>
     <sys_hub_action_type_snapshot action="INSERT_OR_UPDATE">
         <access>public</access>
@@ -1029,10 +1024,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:22</sys_created_on>
         <sys_id>ea488b44db9f51908c045e8cd3961920</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
-        <value>{"version":"1.0","complexObjectSchema":{"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05.$type_facets":{"SimpleMapFacet":"{\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FDe6488b44cf9f51904cdd73311d9d1c05\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"hint\":null,\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"serializationFormat":"JSON"}</value>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:07</sys_updated_on>
+        <value>{"version":"1.0","complexObject":{"code":{"$cv":{"$c":"java.lang.String","$v":""}},"message":{"$cv":{"$c":"java.lang.String","$v":""}}},"complexObjectSchema":{"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05":{"code":"Integer","code.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"Integer\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"integer\",\"default_value\":\"\",\"label\":\"Code\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"1\",\"max_length\":\"40\"}"},"message":"String","message.$field_facets":{"SimpleMapFacet":"{\"uiTypeLabel\":\"String\",\"read_only\":\"false\",\"hint\":\"\",\"uiType\":\"string\",\"default_value\":\"\",\"label\":\"Message\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"order\":\"2\",\"max_length\":\"4000\"}"}},"FlowDesigner:FDe6488b44cf9f51904cdd73311d9d1c05.$type_facets":{"SimpleMapFacet":"{\"default_value\":\"\",\"label\":\"Action Status\",\"action_error_output\":\"true\",\"mandatory\":\"false\",\"uiUniqueId\":\"2aac9e08-2681-46f2-8745-9d48ba3d939f\",\"uiTypeLabel\":\"Object\",\"co_type_name\":\"FDe6488b44cf9f51904cdd73311d9d1c05\",\"element_mapping_provider\":\"com.glide.flow_design.action.data.FlowDesignVariableMapper\",\"read_only\":\"false\",\"hint\":null,\"uiType\":\"object\",\"order\":\"1\",\"max_length\":\"65000\"}"}},"serializationFormat":"JSON"}</value>
         <variable display_value="Action Status">66488b44db9f51908c045e8cd3961908</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_action_output_96484b44db9f51908c045e8cd39619d8^id=96484b44db9f51908c045e8cd39619d8"/>
@@ -1094,10 +1089,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:21</sys_created_on>
         <sys_id>da484b44db9f51908c045e8cd39619f2</sys_id>
-        <sys_mod_count>10</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:07</sys_updated_on>
     </sys_hub_step_instance>
     <sys_variable_value action="delete_multiple" query="document_key=da484b44db9f51908c045e8cd39619f2"/>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -1108,9 +1103,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-16 19:53:21</sys_created_on>
         <sys_id>a6488b44db9f51908c045e8cd3961902</sys_id>
-        <sys_mod_count>9</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 16:53:43</sys_updated_on>
+        <sys_mod_count>10</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:43:07</sys_updated_on>
         <value>(function execute(inputs, outputs) {
   inputs.payload = JSON.parse(inputs.payload);
   outputs.num_events = inputs.payload.length;
@@ -1179,16 +1174,14 @@
             newEnvironmentJobRecord.insert();
           }
         }
-      }
-      else if (operationType === "ADD_ENVIRONMENT") {
-        
+      } else if (operationType === "ADD_ENVIRONMENT") {
         if (event.code === 200) {
           jobRecord.status = "SUCCESS";
           jobRecord.update();
           outputs.num_updates++;
           var environmentRecord = new GlideRecord("x_g_dis_atat_environment");
           environmentRecord.get(jobRecord.environment.sys_id.toString());
-          
+
           // Handle GetProvisioningStatus response (after async process complete)
           if (response.status) {
             environmentRecord.csp_id = response.status.environmentId;                         
@@ -1205,33 +1198,30 @@
           }
           environmentRecord.update();     
         }
-		else if (operationType === "UPDATE_TASK_ORDER") {
-        
-          if (event.code === 200) {
-            jobRecord.status = "SUCCESS";
-            jobRecord.update();
-            outputs.num_updates++;
-            var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
-            taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
+        else {
+          throw new ErrorHandler().createError(
+            "Operation Type '" + operationType + "' is not supported.",
+            new ErrorHandler().METHOD_ERROR
+          );    
+        }
+      } else if (operationType === "UPDATE_TASK_ORDER") {
+        if (event.code === 200) {
+          jobRecord.status = "SUCCESS";
+          jobRecord.update();
+          outputs.num_updates++;
+          var taskOrderRecord = new GlideRecord("x_g_dis_atat_task_order");
+          taskOrderRecord.get(jobRecord.task_order.sys_id.toString());
 
-            taskOrderRecord.provisioned = true;
-            taskOrderRecord.provisioned_date = now;
-            taskOrderRecord.update();     
-          }
-        // TODO: add support for dashboard_link    
+          taskOrderRecord.provisioned = true;
+          taskOrderRecord.provisioned_date = now;
+          taskOrderRecord.update();     
+        }
+      } else {
+        gs.error("Could not find a Provisioning Job record with HOTH Job ID " + snowJobId);
       }
-      else {
-        throw new ErrorHandler().createError(
-          "Operation Type '" + operationType + "' is not supported.",
-          new ErrorHandler().METHOD_ERROR
-        );    
-      }
-    } else {
-      gs.error("Could not find a Provisioning Job record with HOTH Job ID " + snowJobId);
-    }
 
-  });
-})(inputs, outputs);
+    });
+  })(inputs, outputs);
 </value>
         <variable display_value="Script">71aa7f6647032200b4fad7527c9a719b</variable>
     </sys_variable_value>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
@@ -2,48 +2,86 @@
     <sys_hub_flow action="INSERT_OR_UPDATE">
         <access>public</access>
         <acls/>
-        <active>false</active>
+        <active>true</active>
         <annotation/>
         <callable_by_client_api>false</callable_by_client_api>
         <category/>
-        <compiler_build/>
         <copied_from/>
         <copied_from_name/>
         <description>Updates task order information with the CSP upon update to the ATAT: Task Order table</description>
         <internal_name>prov_update_task_order</internal_name>
-        <label_cache>[{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"}]</label_cache>
-        <latest_snapshot/>
-        <master_snapshot/>
+        <label_cache>[{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","rawLabel":"Add New Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","rawLabel":"Add New Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
+        <master_snapshot>9780ae879741311000989fa00153af02</master_snapshot>
         <name>PROV: Update Task Order</name>
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id/>
+        <remote_trigger_id>bf80ae879741311000989fa00153af7f</remote_trigger_id>
         <run_as>system</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
         <show_draft_actions>false</show_draft_actions>
         <show_triggered_flows>false</show_triggered_flows>
-        <status>draft</status>
+        <status>published</status>
         <sys_class_name>sys_hub_flow</sys_class_name>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 16:58:37</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>6</sys_mod_count>
         <sys_name>PROV: Update Task Order</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_e9b36c329741311000989fa00153afb1</sys_update_name>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=e9b36c329741311000989fa00153afb1"/>
     <sys_variable_value action="delete_multiple" query="document_key=e9b36c329741311000989fa00153afb1"/>
+    <sys_flow_record_trigger action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <condition table="x_g_dis_atat_task_order">^EQ<item endquery="true" field="" goto="false" newquery="false" operator="=" or="false" value=""/>
+        </condition>
+        <name/>
+        <on_delete>false</on_delete>
+        <on_insert>false</on_insert>
+        <on_update>true</on_update>
+        <run_flow_in>background</run_flow_in>
+        <run_on_extended>false</run_on_extended>
+        <run_when_setting>both</run_when_setting>
+        <run_when_user_list/>
+        <run_when_user_setting>any</run_when_user_setting>
+        <sys_class_name>sys_flow_record_trigger</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:35</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>bf80ae879741311000989fa00153af7f</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_overrides/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <table>x_g_dis_atat_task_order</table>
+    </sys_flow_record_trigger>
+    <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <data>{"run_flow_in":"background","run_when_user_list":[],"run_when_setting":"both","run_when_user_setting":"any","run_on_extended":"false"}</data>
+        <identifier>e9b36c329741311000989fa00153afb1</identifier>
+        <runner>FDTriggerRunner</runner>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:35</sys_created_on>
+        <sys_id>7b80ae879741311000989fa00153af80</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <trigger display_value="">bf80ae879741311000989fa00153af7f</trigger>
+    </sys_trigger_runner_mapping>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT IN7b80ae879741311000989fa00153af80"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INf12524b29741311000989fa00153affb"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -54,10 +92,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153affb</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>6</sys_mod_count>
         <sys_scope/>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -112,7 +150,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -171,14 +209,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>292524b29741311000989fa00153afee</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -278,7 +316,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -337,14 +375,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153aff6</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -359,14 +397,13 @@
     </sys_hub_flow_input>
     <sys_hub_flow_output action="delete_multiple" query="model=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=e9b36c329741311000989fa00153afb1"/>
-    <sys_hub_action_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INbd2564b29741311000989fa00153af12"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INbd2564b29741311000989fa00153af12,cc05160f9701311000989fa00153afea"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
         <action_inputs/>
         <action_inputs/>
         <action_type display_value="Create Record">2de05916c31332002841b63b12d3aee1</action_type>
         <action_type_parent/>
         <comment/>
-        <compiled_snapshot/>
         <display_text/>
         <flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</flow>
         <order>2</order>
@@ -375,10 +412,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>bd2564b29741311000989fa00153af12</sys_id>
-        <sys_mod_count>4</sys_mod_count>
+        <sys_mod_count>12</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=bd2564b29741311000989fa00153af12"/>
@@ -427,15 +464,77 @@
         <input_name>values</input_name>
         <instance>bd2564b29741311000989fa00153af12</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createAddPortfolioPayload(fd_data.flow_var.hoth_job_id, targetCspName, \"ADD_PORTFOLIO\");","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>f0f5c9fe9781311000989fa00153afb1</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:22</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=bd2564b29741311000989fa00153af12"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Log">5bc1bcc6531003003bf1d9109ec587d4</action_type>
+        <action_type_parent/>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</flow>
+        <order>3</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 19:52:05</sys_created_on>
+        <sys_id>cc05160f9701311000989fa00153afea</sys_id>
+        <sys_mod_count>8</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=cc05160f9701311000989fa00153afea"/>
+    <sys_element_mapping action="delete_multiple" query="id=cc05160f9701311000989fa00153afea"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>log_message</field>
+        <id>cc05160f9701311000989fa00153afea</id>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 19:52:05</sys_created_on>
+        <sys_id>8005160f9701311000989fa00153afed</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 19:52:05</sys_updated_on>
+        <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
+        <value>{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}}{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}{{Updated_1.current.task_order_number}}{{Updated_1.current.sys_id}}</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=cc05160f9701311000989fa00153afea^sys_idNOT IN0005160f9701311000989fa00153afec,4805160f9701311000989fa00153afec"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>false</active>
+        <input_name>log_level</input_name>
+        <instance>cc05160f9701311000989fa00153afea</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"log_level":{"scriptActive":false}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 19:52:05</sys_created_on>
+        <sys_id>0005160f9701311000989fa00153afec</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 19:52:05</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>false</active>
+        <input_name>log_message</input_name>
+        <instance>cc05160f9701311000989fa00153afea</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"log_message":{"scriptActive":false}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 19:52:05</sys_created_on>
+        <sys_id>4805160f9701311000989fa00153afec</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 19:52:05</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=cc05160f9701311000989fa00153afea"/>
     <sys_hub_sub_flow_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_flow_logic action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INb0f5c9fe9781311000989fa00153afac"/>
     <sys_hub_flow_logic action="INSERT_OR_UPDATE">
@@ -459,10 +558,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>b0f5c9fe9781311000989fa00153afac</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -642,6 +741,728 @@
     <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1"/>
     <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_output_e9b36c329741311000989fa00153afb1"/>
     <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_e9b36c329741311000989fa00153afb1"/>
-    <sys_flow_trigger_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
+    <sys_flow_trigger_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1^sys_idNOT INff80ae879741311000989fa00153af81"/>
+    <sys_flow_trigger_plan action="INSERT_OR_UPDATE">
+        <binding_strategy>com.snc.process_flow.engine.binding.OncePerRecord</binding_strategy>
+        <plan/>
+        <plan_id>e9b36c329741311000989fa00153afb1</plan_id>
+        <snapshot>9780ae879741311000989fa00153af02</snapshot>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:35</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>ff80ae879741311000989fa00153af81</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_overrides/>
+        <sys_scope/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <trigger display_value="">bf80ae879741311000989fa00153af7f</trigger>
+    </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <acls/>
+        <active>true</active>
+        <annotation/>
+        <callable_by_client_api>false</callable_by_client_api>
+        <category/>
+        <copied_from/>
+        <copied_from_name/>
+        <description>Updates task order information with the CSP upon update to the ATAT: Task Order table</description>
+        <internal_name>prov_update_task_order</internal_name>
+        <label_cache>[{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","rawLabel":"Add New Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","rawLabel":"Add New Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
+        <master>true</master>
+        <name>PROV: Update Task Order</name>
+        <natlang/>
+        <outputs/>
+        <parent_flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</parent_flow>
+        <remote_trigger_id/>
+        <run_as>system</run_as>
+        <run_with_roles/>
+        <sc_callable>false</sc_callable>
+        <status>published</status>
+        <sys_class_name>sys_hub_flow_snapshot</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:33</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>9780ae879741311000989fa00153af02</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_overrides/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:33</sys_updated_on>
+        <type>flow</type>
+    </sys_hub_flow_snapshot>
+    <sys_translated_text action="delete_multiple" query="documentkey=9780ae879741311000989fa00153af02"/>
+    <sys_variable_value action="delete_multiple" query="document_key=9780ae879741311000989fa00153af02"/>
+    <sys_hub_trigger_instance action="delete_multiple" query="flow=9780ae879741311000989fa00153af02^sys_idNOT IN6780ae879741311000989fa00153af5c"/>
+    <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</flow>
+        <name>Updated</name>
+        <remote_sys_id/>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>6780ae879741311000989fa00153af5c</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
+        <trigger_inputs/>
+        <trigger_outputs/>
+        <trigger_type>record_update</trigger_type>
+    </sys_hub_trigger_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=6780ae879741311000989fa00153af5c"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>6780ae879741311000989fa00153af5c</document_key>
+        <order>100</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2380ae879741311000989fa00153af5e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <value>^EQ</value>
+        <variable display_value="Condition">bb9adea0c31322002841b63b12d3ae67</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>6780ae879741311000989fa00153af5c</document_key>
+        <order>1</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>e380ae879741311000989fa00153af5e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <value>x_g_dis_atat_task_order</value>
+        <variable display_value="Table">1dda12e0c31322002841b63b12d3aea8</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_bb695e60c31322002841b63b12d3aea5^id=6780ae879741311000989fa00153af5c"/>
+    <sys_hub_flow_stage action="delete_multiple" query="flow=9780ae879741311000989fa00153af02"/>
+    <sys_flow_cat_variable_model action="delete_multiple" query="id=9780ae879741311000989fa00153af02^sys_idNOT IN1b80ae879741311000989fa00153af03"/>
+    <sys_flow_cat_variable_model action="INSERT_OR_UPDATE">
+        <id>9780ae879741311000989fa00153af02</id>
+        <name>PROV: Update Task Order</name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:33</sys_created_on>
+        <sys_id>1b80ae879741311000989fa00153af03</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:33</sys_updated_on>
+    </sys_flow_cat_variable_model>
+    <sys_flow_cat_variable action="delete_multiple" query="flow_catalog_model=1b80ae879741311000989fa00153af03"/>
+    <sys_hub_flow_input action="delete_multiple" query="model=9780ae879741311000989fa00153af02^sys_idNOT IN2b80ae879741311000989fa00153af36,5780ae879741311000989fa00153af2e,df80ae879741311000989fa00153af04"/>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>table_name</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">table_name</internal_type>
+        <label>Table Name</label>
+        <mandatory>false</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</model>
+        <model_id>9780ae879741311000989fa00153af02</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <next_element/>
+        <order>101</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2b80ae879741311000989fa00153af36</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>changed_fields</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Changed Fields</label>
+        <mandatory>false</mandatory>
+        <max_length>4000</max_length>
+        <model display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</model>
+        <model_id>9780ae879741311000989fa00153af02</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>5780ae879741311000989fa00153af2e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent>table_name</dependent>
+        <dependent_on_field>table_name</dependent_on_field>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>current</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">document_id</internal_type>
+        <label>Record</label>
+        <mandatory>true</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</model>
+        <model_id>9780ae879741311000989fa00153af02</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:33</sys_created_on>
+        <sys_id>df80ae879741311000989fa00153af04</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:33</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>true</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_output action="delete_multiple" query="model=9780ae879741311000989fa00153af02"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=9780ae879741311000989fa00153af02"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=9780ae879741311000989fa00153af02^sys_idNOT IN6b80ae879741311000989fa00153af52,e780ae879741311000989fa00153af5a"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Create Record">2de05916c31332002841b63b12d3aee1</action_type>
+        <action_type_parent display_value="Create Record">02f0b88cc3c632002841b63b12d3aeff</action_type_parent>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</flow>
+        <order>2</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>6b80ae879741311000989fa00153af52</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=6b80ae879741311000989fa00153af52"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_action_instance</document>
+        <document_key>6b80ae879741311000989fa00153af52</document_key>
+        <order>0</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>6f80ae879741311000989fa00153af54</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <value>x_g_dis_atat_provisioning_job</value>
+        <variable display_value="Table">61e05916c31332002841b63b12d3aee4</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="id=6b80ae879741311000989fa00153af52"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>table_name</field>
+        <id>6b80ae879741311000989fa00153af52</id>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2780ae879741311000989fa00153af54</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value/>
+    </sys_element_mapping>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>values</field>
+        <id>6b80ae879741311000989fa00153af52</id>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>eb80ae879741311000989fa00153af54</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=6b80ae879741311000989fa00153af52^sys_idNOT INeb80ae879741311000989fa00153af53"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>values</input_name>
+        <instance>6b80ae879741311000989fa00153af52</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>eb80ae879741311000989fa00153af53</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=6b80ae879741311000989fa00153af52"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Log">5bc1bcc6531003003bf1d9109ec587d4</action_type>
+        <action_type_parent display_value="Log">0e0ae8c2531003003bf1d9109ec587c8</action_type_parent>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</flow>
+        <order>3</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>e780ae879741311000989fa00153af5a</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=e780ae879741311000989fa00153af5a"/>
+    <sys_element_mapping action="delete_multiple" query="id=e780ae879741311000989fa00153af5a"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>log_message</field>
+        <id>e780ae879741311000989fa00153af5a</id>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2380ae879741311000989fa00153af5c</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
+        <value>{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}}{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}{{Updated_1.current.task_order_number}}{{Updated_1.current.sys_id}}</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=e780ae879741311000989fa00153af5a^sys_idNOT IN2780ae879741311000989fa00153af5b,2b80ae879741311000989fa00153af5b"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>false</active>
+        <input_name>log_level</input_name>
+        <instance>e780ae879741311000989fa00153af5a</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"log_level":{"scriptActive":false}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2780ae879741311000989fa00153af5b</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>false</active>
+        <input_name>log_message</input_name>
+        <instance>e780ae879741311000989fa00153af5a</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"log_message":{"scriptActive":false}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2b80ae879741311000989fa00153af5b</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=e780ae879741311000989fa00153af5a"/>
+    <sys_hub_sub_flow_instance action="delete_multiple" query="flow=9780ae879741311000989fa00153af02"/>
+    <sys_hub_flow_logic action="delete_multiple" query="flow=9780ae879741311000989fa00153af02^sys_idNOT INab80ae879741311000989fa00153af49"/>
+    <sys_hub_flow_logic action="INSERT_OR_UPDATE">
+        <block display_value="">b4f5c9fe9781311000989fa00153afaa</block>
+        <comment/>
+        <connected_to/>
+        <decision_table/>
+        <decision_table_inputs/>
+        <display_text/>
+        <extended_inputs/>
+        <flow display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</flow>
+        <flow_variable/>
+        <flow_variables_assigned>hoth_job_id</flow_variables_assigned>
+        <inputs/>
+        <logic_definition display_value="Set Flow Variables">4f787d1e0f9b0010ecf0cc52ff767ea0</logic_definition>
+        <order>1</order>
+        <outputs_assigned/>
+        <outputs_to_assign/>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_flow_logic</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>ab80ae879741311000989fa00153af49</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
+        <workflow_inputs/>
+        <workflow_reference/>
+    </sys_hub_flow_logic>
+    <sys_variable_value action="delete_multiple" query="document_key=ab80ae879741311000989fa00153af49"/>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_flow_variable_9780ae879741311000989fa00153af02^id=ab80ae879741311000989fa00153af49"/>
+    <sys_hub_flow_logic_ext_input action="delete_multiple" query="model=ab80ae879741311000989fa00153af49"/>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=ab80ae879741311000989fa00153af49^sys_idNOT IN6f80ae879741311000989fa00153af4a"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>hoth_job_id</input_name>
+        <instance>ab80ae879741311000989fa00153af49</instance>
+        <referenced_table>sys_hub_flow_logic</referenced_table>
+        <script>{"hoth_job_id":{"scriptActive":true,"script":"return gs.generateGUID();"}}</script>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>6f80ae879741311000989fa00153af4a</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_pill_compound action="delete_multiple" query="attached_to=9780ae879741311000989fa00153af02"/>
+    <sys_hub_flow_variable action="delete_multiple" query="model=9780ae879741311000989fa00153af02^sys_idNOT IN6380ae879741311000989fa00153af44"/>
+    <sys_hub_flow_variable action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=string,uiTypeLabel=String,uiUniqueId=e0157fa6-7031-4bc4-9501-9e5953fefdb8</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>hoth_job_id</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>HOTH Job ID</label>
+        <mandatory>false</mandatory>
+        <max_length>8000</max_length>
+        <model display_value="PROV: Update Task Order">9780ae879741311000989fa00153af02</model>
+        <model_id>9780ae879741311000989fa00153af02</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_variable_9780ae879741311000989fa00153af02</name>
+        <next_element/>
+        <order>0</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_variable</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>6380ae879741311000989fa00153af44</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>HOTH Job ID</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_variable_6380ae879741311000989fa00153af44</sys_update_name>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_variable>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02^sys_idNOT IN2380ae879741311000989fa00153af3b,9780ae879741311000989fa00153af2a,ef80ae879741311000989fa00153af32"/>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>table_name</element>
+        <help/>
+        <hint/>
+        <label>Table Name</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>2380ae879741311000989fa00153af3b</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>current</element>
+        <help/>
+        <hint/>
+        <label>Record</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>9780ae879741311000989fa00153af2a</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>changed_fields</element>
+        <help/>
+        <hint/>
+        <label>Changed Fields</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 20:42:34</sys_created_on>
+        <sys_id>ef80ae879741311000989fa00153af32</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_input_9780ae879741311000989fa00153af02"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_output_9780ae879741311000989fa00153af02"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_9780ae879741311000989fa00153af02"/>
+    <sys_hub_flow action="UPDATE">
+        <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
+        <latest_snapshot>9780ae879741311000989fa00153af02</latest_snapshot>
+        <compiler_build/>
+    </sys_hub_flow>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
@@ -16,7 +16,7 @@
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id>bf80ae879741311000989fa00153af7f</remote_trigger_id>
+        <remote_trigger_id>32bb72c397c1311000989fa00153af2b</remote_trigger_id>
         <run_as>system</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
@@ -29,7 +29,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>17</sys_mod_count>
         <sys_name>PROV: Update Task Order</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -37,14 +37,14 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_e9b36c329741311000989fa00153afb1</sys_update_name>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=e9b36c329741311000989fa00153afb1"/>
     <sys_variable_value action="delete_multiple" query="document_key=e9b36c329741311000989fa00153afb1"/>
     <sys_flow_record_trigger action="INSERT_OR_UPDATE">
         <active>true</active>
-        <condition table="x_g_dis_atat_task_order">^EQ<item endquery="true" field="" goto="false" newquery="false" operator="=" or="false" value=""/>
+        <condition table="x_g_dis_atat_task_order">csp_idISNOTEMPTY<item endquery="false" field="csp_id" goto="false" newquery="false" operator="ISNOTEMPTY" or="false" value=""/>
         </condition>
         <name/>
         <on_delete>false</on_delete>
@@ -57,15 +57,15 @@
         <run_when_user_setting>any</run_when_user_setting>
         <sys_class_name>sys_flow_record_trigger</sys_class_name>
         <sys_created_by>xander.keele</sys_created_by>
-        <sys_created_on>2023-09-07 20:42:35</sys_created_on>
+        <sys_created_on>2023-09-07 22:41:18</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
-        <sys_id>bf80ae879741311000989fa00153af7f</sys_id>
+        <sys_id>32bb72c397c1311000989fa00153af2b</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_overrides/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <table>x_g_dis_atat_task_order</table>
     </sys_flow_record_trigger>
     <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
@@ -74,14 +74,14 @@
         <identifier>e9b36c329741311000989fa00153afb1</identifier>
         <runner>FDTriggerRunner</runner>
         <sys_created_by>xander.keele</sys_created_by>
-        <sys_created_on>2023-09-07 20:42:35</sys_created_on>
-        <sys_id>7b80ae879741311000989fa00153af80</sys_id>
+        <sys_created_on>2023-09-07 22:41:18</sys_created_on>
+        <sys_id>babb72c397c1311000989fa00153af2b</sys_id>
         <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
-        <trigger display_value="">bf80ae879741311000989fa00153af7f</trigger>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
     </sys_trigger_runner_mapping>
-    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT IN7b80ae879741311000989fa00153af80"/>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT INbabb72c397c1311000989fa00153af2b"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INf12524b29741311000989fa00153affb"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -92,10 +92,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153affb</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>17</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -110,10 +110,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153affc</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
-        <value>^EQ</value>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 22:41:08</sys_updated_on>
+        <value>csp_idISNOTEMPTY</value>
         <variable display_value="Condition">bb9adea0c31322002841b63b12d3ae67</variable>
     </sys_variable_value>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -209,14 +209,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>292524b29741311000989fa00153afee</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -375,14 +375,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153aff6</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -412,10 +412,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>bd2564b29741311000989fa00153af12</sys_id>
-        <sys_mod_count>12</sys_mod_count>
+        <sys_mod_count>34</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=bd2564b29741311000989fa00153af12"/>
@@ -452,11 +452,11 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12564b29741311000989fa00153af15</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 21:25:52</sys_updated_on>
         <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
-        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted</value>
+        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted^job_type=UPDATE_TASK_ORDER</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=bd2564b29741311000989fa00153af12^sys_idNOT INf0f5c9fe9781311000989fa00153afb1"/>
     <sys_hub_input_scripts action="INSERT_OR_UPDATE">
@@ -464,13 +464,13 @@
         <input_name>values</input_name>
         <instance>bd2564b29741311000989fa00153af12</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\npayload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\nreturn payload;","savedValue":""}}</script>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>f0f5c9fe9781311000989fa00153afb1</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>4</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:22</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:16:14</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=bd2564b29741311000989fa00153af12"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -487,10 +487,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 19:52:05</sys_created_on>
         <sys_id>cc05160f9701311000989fa00153afea</sys_id>
-        <sys_mod_count>8</sys_mod_count>
+        <sys_mod_count>30</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=cc05160f9701311000989fa00153afea"/>
@@ -501,11 +501,11 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 19:52:05</sys_created_on>
         <sys_id>8005160f9701311000989fa00153afed</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 19:52:05</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:09</sys_updated_on>
         <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
-        <value>{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}}{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}{{Updated_1.current.task_order_number}}{{Updated_1.current.sys_id}}</value>
+        <value>Inserted Provisioning Job (Sys ID: {{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}} of Type ({{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}) for Task Order {{Updated_1.current.task_order_number}} with SysId of{{Updated_1.current.sys_id}}</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=cc05160f9701311000989fa00153afea^sys_idNOT IN0005160f9701311000989fa00153afec,4805160f9701311000989fa00153afec"/>
     <sys_hub_input_scripts action="INSERT_OR_UPDATE">
@@ -558,10 +558,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>b0f5c9fe9781311000989fa00153afac</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>16</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -752,12 +752,12 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ff80ae879741311000989fa00153af81</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
-        <trigger display_value="">bf80ae879741311000989fa00153af7f</trigger>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
     </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
@@ -788,7 +788,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>9780ae879741311000989fa00153af02</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
@@ -796,7 +796,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:33</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=9780ae879741311000989fa00153af02"/>
@@ -811,10 +811,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6780ae879741311000989fa00153af5c</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:35</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -829,10 +829,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2380ae879741311000989fa00153af5e</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
-        <value>^EQ</value>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <value>csp_idISNOTEMPTY</value>
         <variable display_value="Condition">bb9adea0c31322002841b63b12d3ae67</variable>
     </sys_variable_value>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -869,7 +869,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -928,14 +928,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2b80ae879741311000989fa00153af36</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -952,7 +952,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,co_type_name=FDCollection,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -1011,14 +1011,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>5780ae879741311000989fa00153af2e</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 21:22:19</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1035,7 +1035,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -1094,14 +1094,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:33</sys_created_on>
         <sys_id>df80ae879741311000989fa00153af04</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:33</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1131,10 +1131,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6b80ae879741311000989fa00153af52</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>14</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=6b80ae879741311000989fa00153af52"/>
@@ -1171,11 +1171,11 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>eb80ae879741311000989fa00153af54</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 21:25:59</sys_updated_on>
         <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
-        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted</value>
+        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted^job_type=UPDATE_TASK_ORDER</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=6b80ae879741311000989fa00153af52^sys_idNOT INeb80ae879741311000989fa00153af53"/>
     <sys_hub_input_scripts action="INSERT_OR_UPDATE">
@@ -1183,13 +1183,13 @@
         <input_name>values</input_name>
         <instance>6b80ae879741311000989fa00153af52</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\npayload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\nreturn payload;","savedValue":""}}</script>
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>eb80ae879741311000989fa00153af53</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=6b80ae879741311000989fa00153af52"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -1206,10 +1206,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>e780ae879741311000989fa00153af5a</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>14</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=e780ae879741311000989fa00153af5a"/>
@@ -1220,11 +1220,11 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2380ae879741311000989fa00153af5c</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
-        <value>{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}}{{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}{{Updated_1.current.task_order_number}}{{Updated_1.current.sys_id}}</value>
+        <value>Inserted Provisioning Job (Sys ID: {{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id}} of Type ({{bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type}}) for Task Order {{Updated_1.current.task_order_number}} with SysId of{{Updated_1.current.sys_id}}</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=e780ae879741311000989fa00153af5a^sys_idNOT IN2780ae879741311000989fa00153af5b,2b80ae879741311000989fa00153af5b"/>
     <sys_hub_input_scripts action="INSERT_OR_UPDATE">
@@ -1277,10 +1277,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>ab80ae879741311000989fa00153af49</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_scope/>
+        <sys_mod_count>8</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 20:42:34</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update sys_domain="global" table="sys_hub_flow">
+    <sys_hub_flow action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <acls/>
+        <active>false</active>
+        <annotation/>
+        <callable_by_client_api>false</callable_by_client_api>
+        <category/>
+        <compiler_build/>
+        <copied_from/>
+        <copied_from_name/>
+        <description>Updates task order information with the CSP upon update to the ATAT: Task Order table</description>
+        <internal_name>prov_update_task_order</internal_name>
+        <label_cache>[{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"}]</label_cache>
+        <latest_snapshot/>
+        <master_snapshot/>
+        <name>PROV: Update Task Order</name>
+        <natlang/>
+        <outputs/>
+        <pre_compiled>false</pre_compiled>
+        <remote_trigger_id/>
+        <run_as>system</run_as>
+        <run_with_roles/>
+        <sc_callable>false</sc_callable>
+        <show_draft_actions>false</show_draft_actions>
+        <show_triggered_flows>false</show_triggered_flows>
+        <status>draft</status>
+        <sys_class_name>sys_hub_flow</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:58:37</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_name>PROV: Update Task Order</sys_name>
+        <sys_overrides/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_e9b36c329741311000989fa00153afb1</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <type>flow</type>
+    </sys_hub_flow>
+    <sys_translated_text action="delete_multiple" query="documentkey=e9b36c329741311000989fa00153afb1"/>
+    <sys_variable_value action="delete_multiple" query="document_key=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_trigger_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INf12524b29741311000989fa00153affb"/>
+    <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</flow>
+        <name>Updated</name>
+        <remote_sys_id/>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>f12524b29741311000989fa00153affb</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
+        <trigger_inputs/>
+        <trigger_outputs/>
+        <trigger_type>record_update</trigger_type>
+    </sys_hub_trigger_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=f12524b29741311000989fa00153affb"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>f12524b29741311000989fa00153affb</document_key>
+        <order>100</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>f12524b29741311000989fa00153affc</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <value>^EQ</value>
+        <variable display_value="Condition">bb9adea0c31322002841b63b12d3ae67</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>f12524b29741311000989fa00153affb</document_key>
+        <order>1</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>f92524b29741311000989fa00153affc</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <value>x_g_dis_atat_task_order</value>
+        <variable display_value="Table">1dda12e0c31322002841b63b12d3aea8</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_bb695e60c31322002841b63b12d3aea5^id=f12524b29741311000989fa00153affb"/>
+    <sys_hub_flow_stage action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1"/>
+    <sys_flow_cat_variable_model action="delete_multiple" query="id=e9b36c329741311000989fa00153afb1^sys_idNOT INe5b36c329741311000989fa00153afb2"/>
+    <sys_flow_cat_variable_model action="INSERT_OR_UPDATE">
+        <id>e9b36c329741311000989fa00153afb1</id>
+        <name>PROV: Update Task Order</name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 16:58:37</sys_created_on>
+        <sys_id>e5b36c329741311000989fa00153afb2</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 16:58:37</sys_updated_on>
+    </sys_flow_cat_variable_model>
+    <sys_flow_cat_variable action="delete_multiple" query="flow_catalog_model=e5b36c329741311000989fa00153afb2"/>
+    <sys_hub_flow_input action="delete_multiple" query="model=e9b36c329741311000989fa00153afb1^sys_idNOT IN292524b29741311000989fa00153afee,b92524b29741311000989fa00153aff2,f12524b29741311000989fa00153aff6"/>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent>table_name</dependent>
+        <dependent_on_field>table_name</dependent_on_field>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>current</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">document_id</internal_type>
+        <label>Record</label>
+        <mandatory>true</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</model>
+        <model_id>e9b36c329741311000989fa00153afb1</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>292524b29741311000989fa00153afee</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>true</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,co_type_name=FDCollection,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>changed_fields</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Changed Fields</label>
+        <mandatory>false</mandatory>
+        <max_length>4000</max_length>
+        <model display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</model>
+        <model_id>e9b36c329741311000989fa00153afb1</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>b92524b29741311000989fa00153aff2</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>table_name</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">table_name</internal_type>
+        <label>Table Name</label>
+        <mandatory>false</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</model>
+        <model_id>e9b36c329741311000989fa00153afb1</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <next_element/>
+        <order>101</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>f12524b29741311000989fa00153aff6</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_output action="delete_multiple" query="model=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INbd2564b29741311000989fa00153af12"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Create Record">2de05916c31332002841b63b12d3aee1</action_type>
+        <action_type_parent/>
+        <comment/>
+        <compiled_snapshot/>
+        <display_text/>
+        <flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</flow>
+        <order>2</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>bd2564b29741311000989fa00153af12</sys_id>
+        <sys_mod_count>4</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=bd2564b29741311000989fa00153af12"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_action_instance</document>
+        <document_key>bd2564b29741311000989fa00153af12</document_key>
+        <order>0</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>752564b29741311000989fa00153af15</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <value>x_g_dis_atat_provisioning_job</value>
+        <variable display_value="Table">61e05916c31332002841b63b12d3aee4</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="id=bd2564b29741311000989fa00153af12"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>table_name</field>
+        <id>bd2564b29741311000989fa00153af12</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>3d2564b29741311000989fa00153af14</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value/>
+    </sys_element_mapping>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>values</field>
+        <id>bd2564b29741311000989fa00153af12</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>f12564b29741311000989fa00153af15</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value>status=NOT_STARTED^hoth_job_id={{flow_variable.hoth_job_id}}^task_order={{Updated_1.current}}^title={{Updated_1.current.task_order_number}}^payload=fd-scripted</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=bd2564b29741311000989fa00153af12^sys_idNOT INf0f5c9fe9781311000989fa00153afb1"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>values</input_name>
+        <instance>bd2564b29741311000989fa00153af12</instance>
+        <referenced_table>sys_hub_action_instance</referenced_table>
+        <script>{"payload":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nvar taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(portfolio);\nreturn hoth.createAddPortfolioPayload(fd_data.flow_var.hoth_job_id, targetCspName, \"ADD_PORTFOLIO\");","savedValue":""}}</script>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 19:28:13</sys_created_on>
+        <sys_id>f0f5c9fe9781311000989fa00153afb1</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=bd2564b29741311000989fa00153af12"/>
+    <sys_hub_sub_flow_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_flow_logic action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INb0f5c9fe9781311000989fa00153afac"/>
+    <sys_hub_flow_logic action="INSERT_OR_UPDATE">
+        <block display_value="">b4f5c9fe9781311000989fa00153afaa</block>
+        <comment/>
+        <connected_to/>
+        <decision_table/>
+        <decision_table_inputs/>
+        <display_text/>
+        <extended_inputs/>
+        <flow display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</flow>
+        <flow_variable/>
+        <flow_variables_assigned>hoth_job_id</flow_variables_assigned>
+        <inputs/>
+        <logic_definition display_value="Set Flow Variables">4f787d1e0f9b0010ecf0cc52ff767ea0</logic_definition>
+        <order>1</order>
+        <outputs_assigned/>
+        <outputs_to_assign/>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_flow_logic</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 19:28:13</sys_created_on>
+        <sys_id>b0f5c9fe9781311000989fa00153afac</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+        <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
+        <workflow_inputs/>
+        <workflow_reference/>
+    </sys_hub_flow_logic>
+    <sys_variable_value action="delete_multiple" query="document_key=b0f5c9fe9781311000989fa00153afac"/>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_flow_variable_e9b36c329741311000989fa00153afb1^id=b0f5c9fe9781311000989fa00153afac"/>
+    <sys_hub_flow_logic_ext_input action="delete_multiple" query="model=b0f5c9fe9781311000989fa00153afac"/>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=b0f5c9fe9781311000989fa00153afac^sys_idNOT IN34f5c9fe9781311000989fa00153afad"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>hoth_job_id</input_name>
+        <instance>b0f5c9fe9781311000989fa00153afac</instance>
+        <referenced_table>sys_hub_flow_logic</referenced_table>
+        <script>{"hoth_job_id":{"scriptActive":true,"script":"return gs.generateGUID();"}}</script>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 19:28:13</sys_created_on>
+        <sys_id>34f5c9fe9781311000989fa00153afad</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 19:28:13</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_pill_compound action="delete_multiple" query="attached_to=e9b36c329741311000989fa00153afb1"/>
+    <sys_hub_flow_variable action="delete_multiple" query="model=e9b36c329741311000989fa00153afb1^sys_idNOT IN312524b29741311000989fa00153affe"/>
+    <sys_hub_flow_variable action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=string,uiTypeLabel=String,uiUniqueId=e0157fa6-7031-4bc4-9501-9e5953fefdb8</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>hoth_job_id</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>HOTH Job ID</label>
+        <mandatory>false</mandatory>
+        <max_length>8000</max_length>
+        <model display_value="PROV: Update Task Order">e9b36c329741311000989fa00153afb1</model>
+        <model_id>e9b36c329741311000989fa00153afb1</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_variable_e9b36c329741311000989fa00153afb1</name>
+        <next_element/>
+        <order>0</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_variable</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>312524b29741311000989fa00153affe</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>HOTH Job ID</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_variable_312524b29741311000989fa00153affe</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_variable>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1^sys_idNOT IN352524b29741311000989fa00153aff5,392524b29741311000989fa00153aff8,e92524b29741311000989fa00153aff1"/>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>changed_fields</element>
+        <help/>
+        <hint/>
+        <label>Changed Fields</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>352524b29741311000989fa00153aff5</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>table_name</element>
+        <help/>
+        <hint/>
+        <label>Table Name</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>392524b29741311000989fa00153aff8</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>current</element>
+        <help/>
+        <hint/>
+        <label>Record</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-06 17:04:55</sys_created_on>
+        <sys_id>e92524b29741311000989fa00153aff1</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-06 17:04:55</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_input_e9b36c329741311000989fa00153afb1"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_output_e9b36c329741311000989fa00153afb1"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_e9b36c329741311000989fa00153afb1"/>
+    <sys_flow_trigger_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
+    <sys_flow_subflow_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
@@ -277,7 +277,6 @@ HothProvisioning.prototype = {
   * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
   * @param {string} targetCsp - the CSP being targeted for this provision request
   * @param {string} taskOrderSysId - the sys_id of the task order record within ServiceNow
-  * @param {string} taskOrderCSPId - the id of the task order in the CSP system
   * @return {Object} an object for updating a task order
   * 
   */
@@ -292,12 +291,12 @@ HothProvisioning.prototype = {
 
 			const taskOrder = this.getTaskOrder(taskOrderSysId.toString());
 			gs.info("createUpdateTaskOrderPayload => " + JSON.stringify(taskOrder));
-// 			if (!taskOrder.csp_id) {
-// 				throw this.errUtil.createError(
-// 					"taskOrder must have a valid CSP ID to update.",
-// 					this.errUtil.INVALID_INPUT
-// 				);
-// 			}
+			if (!taskOrder.csp_id) {
+				throw this.errUtil.createError(
+					"taskOrder must have a valid CSP ID to update.",
+					this.errUtil.INVALID_INPUT
+				);
+			}
 
 			return {
 				jobId: hothId,
@@ -326,13 +325,13 @@ HothProvisioning.prototype = {
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2023-02-28 20:22:38</sys_created_on>
         <sys_id>f563b62d47152110f39f7601e36d43de</sys_id>
-        <sys_mod_count>62</sys_mod_count>
+        <sys_mod_count>63</sys_mod_count>
         <sys_name>HothProvisioning</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_f563b62d47152110f39f7601e36d43de</sys_update_name>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:36:40</sys_updated_on>
+        <sys_updated_on>2023-09-07 22:52:24</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
@@ -13,7 +13,7 @@ following locations:&#13;
 - PROV: Queue Initial Portfolio Provisioning Job (action)&#13;
 </description>
         <name>HothProvisioning</name>
-        <script><![CDATA[var HothProvisioning = Class.create();
+        <script><![CDATA[const HothProvisioning = Class.create();
 HothProvisioning.prototype = {
 	PORTFOLIO_TABLE: "x_g_dis_atat_portfolio",
 	TASK_ORDER_TABLE: "x_g_dis_atat_task_order",
@@ -34,7 +34,7 @@ HothProvisioning.prototype = {
 			this.portfolio = portfolioRecord;
 		}
 	},
-	
+
 	/**
    * Truncates the days from Date Strings. Temporarily needed because of a mistaken change in the ATAT 1.1.0 specification.
    *
@@ -57,7 +57,7 @@ HothProvisioning.prototype = {
    * @return {string} HOTH-formatted Date
    */
 	convertClassificationToHothFormat: function(snowClassification) {
-		var classificationMap = {
+		const classificationMap = {
 			U: "UNCLASSIFIED",
 			S: "SECRET",
 			TS: "TOP_SECRET"
@@ -72,7 +72,7 @@ HothProvisioning.prototype = {
    * @return {string} SNOW-formatted Date
    */	
 	convertClassificationToSnowFormat: function(hothClassification) {
-		var classificationMap = {
+		const classificationMap = {
 			"UNCLASSIFIED" : "U",
 			"SECRET": "S",
 			"TOP_SECRET": "TS"
@@ -88,14 +88,10 @@ HothProvisioning.prototype = {
    */
 	getClins: function(taskOrderSysId) {
 		try {
-			var clinTableFields = [
-				"clin_number", "pop_start_date", "pop_end_date", "classification_level", "type", 
-			];
-			
-			var scope = this;
-			
-			var clins = [];
-			var clinRecord = new GlideRecord(this.CLIN_TABLE);
+			const scope = this;
+
+			let clins = [];
+			const clinRecord = new GlideRecord(this.CLIN_TABLE);
 			clinRecord.addQuery("task_order", taskOrderSysId);
 			clinRecord.query();
 			while (clinRecord.hasNext()) {
@@ -133,14 +129,14 @@ HothProvisioning.prototype = {
    */
 	getTaskOrders: function() {
 		try {
-			var taskOrders = [];
-			var taskOrderRecords = new GlideRecord(this.TASK_ORDER_TABLE);
+			let taskOrders = [];
+			const taskOrderRecords = new GlideRecord(this.TASK_ORDER_TABLE);
 			taskOrderRecords.addQuery("portfolio", this.portfolio.sys_id.toString());
 			taskOrderRecords.query();
-			
+
 			while (taskOrderRecords.next()) {
 				// Get Task Order CLINs
-				var taskOrderClins = this.getClins(taskOrderRecords.sys_id.toString());		
+				const taskOrderClins = this.getClins(taskOrderRecords.sys_id.toString());		
 
 				// Gather Task Orders for a given Portfolio
 				taskOrders.push({
@@ -159,14 +155,45 @@ HothProvisioning.prototype = {
 			);
 		}
 	},
+
 	/**
-   * Construct a request to provision a Portfolio using the HOTH API.
+   * Get Task Order with a provided TaskOrderNumber
    *
-   * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
-   * @param {string} targetCsp - a GUID generated within ServiceNow
-   * @param {string} operation - the provisioning operation (e.g., ADD_ENVIRONMENT)
-   * @return {Object} an object for provisioning a portfolio
+   * @param {string} taskOrderSysId
+   * @return {Object[]} an array of task orders 
    */
+	getTaskOrder: function(taskOrderSysId) {
+		try {
+			const taskOrderRecord = new GlideRecord(this.TASK_ORDER_TABLE);
+			taskOrderRecord.get(taskOrderSysId);
+			if (taskOrderRecord !== undefined) {
+				// Get Task Order CLINs
+				const taskOrderClins = this.getClins(taskOrderSysId);		
+
+				// Gather Task Orders for a given Portfolio
+				return {
+					taskOrderNumber: taskOrderRecord.task_order_number.toString(),
+					popStartDate: this.truncateDayFromDate(taskOrderRecord.pop_start_date.toString()),
+					popEndDate: this.truncateDayFromDate(taskOrderRecord.pop_end_date.toString()),
+					clins: taskOrderClins,
+				};
+			}
+		} catch (error) {
+			throw this.errUtil.createError(
+				"HothProvisioning --> getTaskOrder(): " + error,
+				this.errUtil.METHOD_ERROR
+			);
+		}
+	},
+
+	/**
+  * Construct a request to provision a Portfolio using the HOTH API.
+  *
+  * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
+  * @param {string} targetCsp - the CSP being targeted for this provision request
+  * @return {Object} an object for provisioning a portfolio
+  * 
+  */
 	createAddPortfolioPayload: function(hothId, targetCsp) {
 		try {
 			if (!hothId || !targetCsp) {
@@ -175,8 +202,8 @@ HothProvisioning.prototype = {
 					this.errUtil.INVALID_INPUT
 				);
 			}
-		
-			var taskOrders = this.getTaskOrders(this.portfolio.sys_id.toString());
+
+			const taskOrders = this.getTaskOrders(this.portfolio.sys_id.toString());
 
 			return {
 				jobId: hothId,
@@ -190,7 +217,7 @@ HothProvisioning.prototype = {
 			};
 
 		} catch (error) {
-			var errorMessage = "Error creating an Add Portfolio payload. " + error;
+			const errorMessage = "Error creating an Add Portfolio payload. " + error;
 			this.errUtil.createError(
 				errorMessage,
 				this.errUtil.INVALID_INPUT
@@ -203,6 +230,7 @@ HothProvisioning.prototype = {
    *
    * @param {string} environmentRecord - the Environment being provisioned
    * @return {Object} a valid ADD_ENVIRONMENT Provisioning Job Payload
+   * 
    */
 	createAddEnvironmentPayload: function(environmentRecord) {
 		if (!environmentRecord) {
@@ -212,9 +240,9 @@ HothProvisioning.prototype = {
 			);
 		}
 
-		var scope = this;
-		var hothClassificationLevel = this.convertClassificationToHothFormat(environmentRecord.classification_level.toString());
-		var jobPayload = {
+		const scope = this;
+		const hothClassificationLevel = this.convertClassificationToHothFormat(environmentRecord.classification_level.toString());
+		const jobPayload = {
 			jobId: gs.generateGUID(),
 			userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
 			operationType: "ADD_ENVIRONMENT",
@@ -227,7 +255,7 @@ HothProvisioning.prototype = {
 				administrators: environmentRecord.pending_operators ? 
 				environmentRecord.pending_operators.toString().split(",")
 				.map(function (operatorSysId) {
-					var record = new GlideRecord(scope.OPERATOR_TABLE);
+					const record = new GlideRecord(scope.OPERATOR_TABLE);
 					record.get(operatorSysId);
 					return {
 						email: record.email.toString(),
@@ -243,19 +271,68 @@ HothProvisioning.prototype = {
 		return jobPayload;
 	},	
 
+	/**
+  * Construct a request to update a TaskOrder using the HOTH API.
+  *
+  * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
+  * @param {string} targetCsp - the CSP being targeted for this provision request
+  * @param {string} taskOrderSysId - the sys_id of the task order record within ServiceNow
+  * @param {string} taskOrderCSPId - the id of the task order in the CSP system
+  * @return {Object} an object for updating a task order
+  * 
+  */
+	createUpdateTaskOrderPayload: function(hothId, targetCsp, taskOrderSysId) {
+		try {
+			if (!hothId || !targetCsp) {
+				throw this.errUtil.createError(
+					"hothId and targetCsp must be provided.",
+					this.errUtil.INVALID_INPUT
+				);
+			}
+
+			const taskOrder = this.getTaskOrder(taskOrderSysId.toString());
+			gs.info("createUpdateTaskOrderPayload => " + JSON.stringify(taskOrder));
+// 			if (!taskOrder.csp_id) {
+// 				throw this.errUtil.createError(
+// 					"taskOrder must have a valid CSP ID to update.",
+// 					this.errUtil.INVALID_INPUT
+// 				);
+// 			}
+
+			return {
+				jobId: hothId,
+				userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
+				operationType: "UPDATE_TASK_ORDER",
+				targetCspName: targetCsp.toString(), 
+				payload: {
+					portfolioId: this.portfolio.csp_id ? this.portfolio.csp_id.toString() : "",
+					taskOrderId: taskOrder.csp_id ? taskOrder.csp_id.toString() : "",
+					taskOrder: taskOrder,
+				},
+			};
+
+		} catch (error) {
+			const errorMessage = "Error creating an Update TaskOrder payload. " + error;
+			this.errUtil.createError(
+				errorMessage,
+				this.errUtil.INVALID_INPUT
+			);
+		}
+	},
+
 	type: 'HothProvisioning'
 };]]></script>
         <sys_class_name>sys_script_include</sys_class_name>
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2023-02-28 20:22:38</sys_created_on>
         <sys_id>f563b62d47152110f39f7601e36d43de</sys_id>
-        <sys_mod_count>48</sys_mod_count>
+        <sys_mod_count>62</sys_mod_count>
         <sys_name>HothProvisioning</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_f563b62d47152110f39f7601e36d43de</sys_update_name>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-04-05 15:42:39</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 22:36:40</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_a248816087141110fb40a68d0ebb3560.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_a248816087141110fb40a68d0ebb3560.xml
@@ -84,6 +84,34 @@
             <sys_user/>
             <type/>
         </sys_ui_element>
+        <sys_ui_element action="INSERT_OR_UPDATE">
+            <element>provisioned</element>
+            <position>6</position>
+            <sys_created_by>admin</sys_created_by>
+            <sys_created_on>2023-09-06 16:35:53</sys_created_on>
+            <sys_id>d48e18fa9701311000989fa00153af60</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_ui_formatter/>
+            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_task_order" sys_domain="global" view="Default view">a248816087141110fb40a68d0ebb3560</sys_ui_section>
+            <sys_updated_by>admin</sys_updated_by>
+            <sys_updated_on>2023-09-06 16:35:53</sys_updated_on>
+            <sys_user/>
+            <type/>
+        </sys_ui_element>
+        <sys_ui_element action="INSERT_OR_UPDATE">
+            <element>provisioned_date</element>
+            <position>7</position>
+            <sys_created_by>admin</sys_created_by>
+            <sys_created_on>2023-09-06 16:36:45</sys_created_on>
+            <sys_id>45be98fa9701311000989fa00153af89</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_ui_formatter/>
+            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_task_order" sys_domain="global" view="Default view">a248816087141110fb40a68d0ebb3560</sys_ui_section>
+            <sys_updated_by>admin</sys_updated_by>
+            <sys_updated_on>2023-09-06 16:36:45</sys_updated_on>
+            <sys_user/>
+            <type/>
+        </sys_ui_element>
         <sys_ui_section action="INSERT_OR_UPDATE">
             <caption/>
             <header>false</header>


### PR DESCRIPTION
Created new flow to create provisioning job record for new UpdateTaskOrder in CSP. Modeled after `PROV: Queue Initial Portfolio Provisioning Job` and triggered on any record update on the `ATAT:Task Order` table with the condition that it has a `csp_id` field already populated.
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/62ca6ecf-7228-4738-9c2b-9a76e653e1a4)

![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/97b482fe-3111-4dea-981c-e4f13c4714da)

![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/0299d1c2-b4e3-4e0a-bafa-743bf8a5e14b)

`HothProvisioning` Script Include was also updated with a new function to create the UpdateTaskOrderRequest object to send to the HOTH API.
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/0869c963-5745-402d-a21a-a27c829de8c1)

Adjusted `PROV: Consume Queue Payload` to account for the new `UPDATE_TASK_ORDER` job type
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/11f903f9-44ed-44a5-a19f-afe980c44754)

Also added `CSP Id`, `Provisioned`, and `Provisioned Date` fields to `ATAT:Task Order` table. 