### PR TITLE
AT-9649: Updated CSP - Unique Name business rule 

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_1df1aab197e22110cf3cfd9fe153af2a.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_1df1aab197e22110cf3cfd9fe153af2a.xml
@@ -33,6 +33,8 @@
     // check for unique Name
     var gr = new GlideRecord(current.getTableName());
     gr.addQuery("name", current.name);
+	// Exclude this record from the query
+	gr.addQuery("sys_id", "!=", current.sys_id);
     gr.query();
     if (gr.getRowCount()) {
         current.setAbortAction(true);
@@ -67,15 +69,15 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>1df1aab197e22110cf3cfd9fe153af2a</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name>CSP - Unique Name</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_1df1aab197e22110cf3cfd9fe153af2a</sys_update_name>
-        <sys_updated_by>jason.d.burkert.ctr@mail.mil</sys_updated_by>
-        <sys_updated_on>2023-05-02 17:02:26</sys_updated_on>
+        <sys_updated_by>1370228783.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 02:56:05</sys_updated_on>
         <template/>
         <when>before</when>
     </sys_script>


### PR DESCRIPTION
Modified query to exclude current record so that we can actually change records without renaming them.