### PR TITLE
Bugfix/AT-9691 - Functional testing bugs for `PROV: Update Task Order`

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
@@ -16,7 +16,7 @@
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id>2277fa934705315093e530ed436d439e</remote_trigger_id>
+        <remote_trigger_id>32bb72c397c1311000989fa00153af2b</remote_trigger_id>
         <run_as>system</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
@@ -29,7 +29,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_name>PROV: Update Task Order</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -37,7 +37,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_e9b36c329741311000989fa00153afb1</sys_update_name>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:49:50</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=e9b36c329741311000989fa00153afb1"/>
@@ -56,16 +56,16 @@
         <run_when_user_list/>
         <run_when_user_setting>any</run_when_user_setting>
         <sys_class_name>sys_flow_record_trigger</sys_class_name>
-        <sys_created_by>1609291318.CTR</sys_created_by>
-        <sys_created_on>2023-09-08 17:01:12</sys_created_on>
+        <sys_created_by>xander.keele</sys_created_by>
+        <sys_created_on>2023-09-07 22:41:18</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
-        <sys_id>2277fa934705315093e530ed436d439e</sys_id>
+        <sys_id>32bb72c397c1311000989fa00153af2b</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_overrides/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_by>xander.keele</sys_updated_by>
+        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
         <table>x_g_dis_atat_task_order</table>
     </sys_flow_record_trigger>
     <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
@@ -74,14 +74,14 @@
         <identifier>e9b36c329741311000989fa00153afb1</identifier>
         <runner>FDTriggerRunner</runner>
         <sys_created_by>1609291318.CTR</sys_created_by>
-        <sys_created_on>2023-09-08 17:01:12</sys_created_on>
-        <sys_id>ea77fa934705315093e530ed436d439e</sys_id>
+        <sys_created_on>2023-09-08 17:54:51</sys_created_on>
+        <sys_id>a8c34fdf4745315093e530ed436d43e0</sys_id>
         <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
-        <trigger display_value="">2277fa934705315093e530ed436d439e</trigger>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
+        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
     </sys_trigger_runner_mapping>
-    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT INea77fa934705315093e530ed436d439e"/>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT INa8c34fdf4745315093e530ed436d43e0"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INf12524b29741311000989fa00153affb"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -92,10 +92,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153affb</sys_id>
-        <sys_mod_count>21</sys_mod_count>
+        <sys_mod_count>24</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -209,14 +209,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>292524b29741311000989fa00153afee</sys_id>
-        <sys_mod_count>9</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -375,14 +375,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153aff6</sys_id>
-        <sys_mod_count>9</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -412,10 +412,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>bd2564b29741311000989fa00153af12</sys_id>
-        <sys_mod_count>42</sys_mod_count>
+        <sys_mod_count>48</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=bd2564b29741311000989fa00153af12"/>
@@ -464,13 +464,13 @@
         <input_name>values</input_name>
         <instance>bd2564b29741311000989fa00153af12</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nvar payload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\ngs.info(\"PROV:Update Task Order \u003d\u003e Payload \u003d \" + payload);\nreturn payload;","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>f0f5c9fe9781311000989fa00153afb1</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:02</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:43</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=bd2564b29741311000989fa00153af12"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -487,10 +487,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 19:52:05</sys_created_on>
         <sys_id>cc05160f9701311000989fa00153afea</sys_id>
-        <sys_mod_count>38</sys_mod_count>
+        <sys_mod_count>44</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=cc05160f9701311000989fa00153afea"/>
@@ -558,10 +558,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>b0f5c9fe9781311000989fa00153afac</sys_id>
-        <sys_mod_count>21</sys_mod_count>
+        <sys_mod_count>24</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -682,7 +682,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>352524b29741311000989fa00153aff5</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Changed Fields</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -705,7 +705,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>392524b29741311000989fa00153aff8</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Table Name</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -728,7 +728,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>e92524b29741311000989fa00153aff1</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Record</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -752,12 +752,12 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ff80ae879741311000989fa00153af81</sys_id>
-        <sys_mod_count>4</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
-        <trigger display_value="">2277fa934705315093e530ed436d439e</trigger>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
+        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
     </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
@@ -788,7 +788,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>9780ae879741311000989fa00153af02</sys_id>
-        <sys_mod_count>4</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
@@ -796,7 +796,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=9780ae879741311000989fa00153af02"/>
@@ -811,10 +811,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6780ae879741311000989fa00153af5c</sys_id>
-        <sys_mod_count>14</sys_mod_count>
+        <sys_mod_count>17</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -928,14 +928,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2b80ae879741311000989fa00153af36</sys_id>
-        <sys_mod_count>7</sys_mod_count>
+        <sys_mod_count>9</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:50</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1094,14 +1094,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:33</sys_created_on>
         <sys_id>df80ae879741311000989fa00153af04</sys_id>
-        <sys_mod_count>7</sys_mod_count>
+        <sys_mod_count>9</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:50</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1131,10 +1131,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6b80ae879741311000989fa00153af52</sys_id>
-        <sys_mod_count>18</sys_mod_count>
+        <sys_mod_count>22</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:50</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=6b80ae879741311000989fa00153af52"/>
@@ -1183,13 +1183,13 @@
         <input_name>values</input_name>
         <instance>6b80ae879741311000989fa00153af52</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nvar payload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\ngs.info(\"PROV:Update Task Order \u003d\u003e Payload \u003d \" + payload);\nreturn payload;","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nreturn hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);","savedValue":""}}</script>
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>eb80ae879741311000989fa00153af53</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>4</sys_mod_count>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:50</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=6b80ae879741311000989fa00153af52"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -1206,10 +1206,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>e780ae879741311000989fa00153af5a</sys_id>
-        <sys_mod_count>18</sys_mod_count>
+        <sys_mod_count>22</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:51</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=e780ae879741311000989fa00153af5a"/>
@@ -1277,10 +1277,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>ab80ae879741311000989fa00153af49</sys_id>
-        <sys_mod_count>11</sys_mod_count>
+        <sys_mod_count>13</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>1609291318.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
+        <sys_updated_on>2023-09-08 17:54:50</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -1401,7 +1401,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2380ae879741311000989fa00153af3b</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Table Name</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -1424,7 +1424,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>9780ae879741311000989fa00153af2a</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Record</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -1447,7 +1447,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>ef80ae879741311000989fa00153af32</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name>Changed Fields</sys_name>
+        <sys_name/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_e9b36c329741311000989fa00153afb1.xml
@@ -10,13 +10,13 @@
         <copied_from_name/>
         <description>Updates task order information with the CSP upon update to the ATAT: Task Order table</description>
         <internal_name>prov_update_task_order</internal_name>
-        <label_cache>[{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","rawLabel":"Add New Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","rawLabel":"Add New Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
+        <label_cache>[{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","rawLabel":"Add New Environment","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","rawLabel":"Add New Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"}]</label_cache>
         <master_snapshot>9780ae879741311000989fa00153af02</master_snapshot>
         <name>PROV: Update Task Order</name>
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id>32bb72c397c1311000989fa00153af2b</remote_trigger_id>
+        <remote_trigger_id>2277fa934705315093e530ed436d439e</remote_trigger_id>
         <run_as>system</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
@@ -29,15 +29,15 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>e9b36c329741311000989fa00153afb1</sys_id>
-        <sys_mod_count>17</sys_mod_count>
+        <sys_mod_count>0</sys_mod_count>
         <sys_name>PROV: Update Task Order</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_e9b36c329741311000989fa00153afb1</sys_update_name>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:49:50</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=e9b36c329741311000989fa00153afb1"/>
@@ -56,16 +56,16 @@
         <run_when_user_list/>
         <run_when_user_setting>any</run_when_user_setting>
         <sys_class_name>sys_flow_record_trigger</sys_class_name>
-        <sys_created_by>xander.keele</sys_created_by>
-        <sys_created_on>2023-09-07 22:41:18</sys_created_on>
+        <sys_created_by>1609291318.CTR</sys_created_by>
+        <sys_created_on>2023-09-08 17:01:12</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
-        <sys_id>32bb72c397c1311000989fa00153af2b</sys_id>
+        <sys_id>2277fa934705315093e530ed436d439e</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_overrides/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <table>x_g_dis_atat_task_order</table>
     </sys_flow_record_trigger>
     <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
@@ -73,15 +73,15 @@
         <data>{"run_flow_in":"background","run_when_user_list":[],"run_when_setting":"both","run_when_user_setting":"any","run_on_extended":"false"}</data>
         <identifier>e9b36c329741311000989fa00153afb1</identifier>
         <runner>FDTriggerRunner</runner>
-        <sys_created_by>xander.keele</sys_created_by>
-        <sys_created_on>2023-09-07 22:41:18</sys_created_on>
-        <sys_id>babb72c397c1311000989fa00153af2b</sys_id>
+        <sys_created_by>1609291318.CTR</sys_created_by>
+        <sys_created_on>2023-09-08 17:01:12</sys_created_on>
+        <sys_id>ea77fa934705315093e530ed436d439e</sys_id>
         <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
-        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <trigger display_value="">2277fa934705315093e530ed436d439e</trigger>
     </sys_trigger_runner_mapping>
-    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT INbabb72c397c1311000989fa00153af2b"/>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=e9b36c329741311000989fa00153afb1^sys_idNOT INea77fa934705315093e530ed436d439e"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INf12524b29741311000989fa00153affb"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -92,10 +92,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153affb</sys_id>
-        <sys_mod_count>17</sys_mod_count>
+        <sys_mod_count>21</sys_mod_count>
         <sys_scope/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -209,14 +209,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>292524b29741311000989fa00153afee</sys_id>
-        <sys_mod_count>7</sys_mod_count>
+        <sys_mod_count>9</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -375,14 +375,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>f12524b29741311000989fa00153aff6</sys_id>
-        <sys_mod_count>7</sys_mod_count>
+        <sys_mod_count>9</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -412,10 +412,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>bd2564b29741311000989fa00153af12</sys_id>
-        <sys_mod_count>34</sys_mod_count>
+        <sys_mod_count>42</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=bd2564b29741311000989fa00153af12"/>
@@ -464,13 +464,13 @@
         <input_name>values</input_name>
         <instance>bd2564b29741311000989fa00153af12</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\npayload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\nreturn payload;","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nvar payload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\ngs.info(\"PROV:Update Task Order \u003d\u003e Payload \u003d \" + payload);\nreturn payload;","savedValue":""}}</script>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>f0f5c9fe9781311000989fa00153afb1</sys_id>
-        <sys_mod_count>4</sys_mod_count>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:16:14</sys_updated_on>
+        <sys_mod_count>6</sys_mod_count>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:02</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=bd2564b29741311000989fa00153af12"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -487,10 +487,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 19:52:05</sys_created_on>
         <sys_id>cc05160f9701311000989fa00153afea</sys_id>
-        <sys_mod_count>30</sys_mod_count>
+        <sys_mod_count>38</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=cc05160f9701311000989fa00153afea"/>
@@ -538,7 +538,7 @@
     <sys_hub_sub_flow_instance action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_flow_logic action="delete_multiple" query="flow=e9b36c329741311000989fa00153afb1^sys_idNOT INb0f5c9fe9781311000989fa00153afac"/>
     <sys_hub_flow_logic action="INSERT_OR_UPDATE">
-        <block display_value="">b4f5c9fe9781311000989fa00153afaa</block>
+        <block display_value="">0d85f25f4781315093e530ed436d4376</block>
         <comment/>
         <connected_to/>
         <decision_table/>
@@ -558,10 +558,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-06 19:28:13</sys_created_on>
         <sys_id>b0f5c9fe9781311000989fa00153afac</sys_id>
-        <sys_mod_count>16</sys_mod_count>
+        <sys_mod_count>21</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -682,7 +682,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>352524b29741311000989fa00153aff5</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Changed Fields</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -705,7 +705,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>392524b29741311000989fa00153aff8</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Table Name</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -728,7 +728,7 @@
         <sys_created_on>2023-09-06 17:04:55</sys_created_on>
         <sys_id>e92524b29741311000989fa00153aff1</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Record</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -752,12 +752,12 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>ff80ae879741311000989fa00153af81</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>4</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
-        <trigger display_value="">32bb72c397c1311000989fa00153af2b</trigger>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
+        <trigger display_value="">2277fa934705315093e530ed436d439e</trigger>
     </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=e9b36c329741311000989fa00153afb1"/>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
@@ -771,7 +771,7 @@
         <copied_from_name/>
         <description>Updates task order information with the CSP upon update to the ATAT: Task Order table</description>
         <internal_name>prov_update_task_order</internal_name>
-        <label_cache>[{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","rawLabel":"Add New Environment","selected":false,"missing":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","rawLabel":"Add New Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
+        <label_cache>[{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Updated_1.current.sys_id","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_task_order","column_name":"sys_id"},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","rawLabel":"Add New Environment","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","rawLabel":"Add New Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"image":"","used":false,"reference":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"bdf041c8-de2e-4884-838a-00dbeed44fd9.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"e0157fa6-7031-4bc4-9501-9e5953fefdb8"}},{"name":"Updated_1.current","label":"Trigger - Record Updated➛ATAT:Task Order Record","reference":"x_g_dis_atat_task_order","reference_display":"ATAT:Task Order","type":"reference","base_type":"reference","attributes":{}},{"name":"Updated_1.current.task_order_number","label":"Trigger - Record Updated➛ATAT:Task Order Record➛Task Order Number","reference":"","reference_display":"Task Order Number","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_task_order","column_name":"task_order_number"}]</label_cache>
         <master>true</master>
         <name>PROV: Update Task Order</name>
         <natlang/>
@@ -788,15 +788,15 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>9780ae879741311000989fa00153af02</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>4</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=9780ae879741311000989fa00153af02"/>
@@ -811,10 +811,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6780ae879741311000989fa00153af5c</sys_id>
-        <sys_mod_count>11</sys_mod_count>
+        <sys_mod_count>14</sys_mod_count>
         <sys_scope/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:18</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:12</sys_updated_on>
         <trigger_definition display_value="Updated">bb695e60c31322002841b63b12d3aea5</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -928,14 +928,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2b80ae879741311000989fa00153af36</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1094,14 +1094,14 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:33</sys_created_on>
         <sys_id>df80ae879741311000989fa00153af04</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>7</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1131,10 +1131,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>6b80ae879741311000989fa00153af52</sys_id>
-        <sys_mod_count>14</sys_mod_count>
+        <sys_mod_count>18</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <ui_id>bdf041c8-de2e-4884-838a-00dbeed44fd9</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=6b80ae879741311000989fa00153af52"/>
@@ -1183,13 +1183,13 @@
         <input_name>values</input_name>
         <instance>6b80ae879741311000989fa00153af52</instance>
         <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\npayload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\nreturn payload;","savedValue":""}}</script>
+        <script>{"payload":{"scriptActive":true,"script":"var taskOrder \u003d fd_data.trigger.current;\nvar targetCspName \u003d fd_data.trigger.current.portfolio.csp.name;\nvar hoth \u003d new HothProvisioning(fd_data.trigger.current.portfolio);\nvar payload \u003d hoth.createUpdateTaskOrderPayload(fd_data.flow_var.hoth_job_id, targetCspName, taskOrder.sys_id);\ngs.info(\"PROV:Update Task Order \u003d\u003e Payload \u003d \" + payload);\nreturn payload;","savedValue":""}}</script>
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>eb80ae879741311000989fa00153af53</sys_id>
-        <sys_mod_count>2</sys_mod_count>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=6b80ae879741311000989fa00153af52"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -1206,10 +1206,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>e780ae879741311000989fa00153af5a</sys_id>
-        <sys_mod_count>14</sys_mod_count>
+        <sys_mod_count>18</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <ui_id>5a2348c8-81ae-42d0-9e68-b63c67ce0870</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=e780ae879741311000989fa00153af5a"/>
@@ -1257,7 +1257,7 @@
     <sys_hub_sub_flow_instance action="delete_multiple" query="flow=9780ae879741311000989fa00153af02"/>
     <sys_hub_flow_logic action="delete_multiple" query="flow=9780ae879741311000989fa00153af02^sys_idNOT INab80ae879741311000989fa00153af49"/>
     <sys_hub_flow_logic action="INSERT_OR_UPDATE">
-        <block display_value="">b4f5c9fe9781311000989fa00153afaa</block>
+        <block display_value="">0d85f25f4781315093e530ed436d4376</block>
         <comment/>
         <connected_to/>
         <decision_table/>
@@ -1277,10 +1277,10 @@
         <sys_created_by>xander.keele</sys_created_by>
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>ab80ae879741311000989fa00153af49</sys_id>
-        <sys_mod_count>8</sys_mod_count>
+        <sys_mod_count>11</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:41:17</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:01:11</sys_updated_on>
         <ui_id>4f599d84-a1bd-4b5c-8ae0-1ef5b971d1a6</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -1401,7 +1401,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>2380ae879741311000989fa00153af3b</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Table Name</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -1424,7 +1424,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>9780ae879741311000989fa00153af2a</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Record</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
@@ -1447,7 +1447,7 @@
         <sys_created_on>2023-09-07 20:42:34</sys_created_on>
         <sys_id>ef80ae879741311000989fa00153af32</sys_id>
         <sys_mod_count>0</sys_mod_count>
-        <sys_name/>
+        <sys_name>Changed Fields</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
@@ -183,8 +183,8 @@ Eda.prototype = {
         let existingTaskOrderSysId = "";
 
         if (toRecord.next()) {
-            existingPortfolioName = toRecord.portfolio.name;
-            existingTaskOrderSysId = toRecord.sys_id;
+            existingPortfolioName = toRecord.portfolio?.name.toString() ?? "";
+            existingTaskOrderSysId = toRecord.sys_id.toString();
         }
 
         this.taskOrder = {
@@ -645,13 +645,13 @@ Eda.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-01-24 02:42:04</sys_created_on>
         <sys_id>abc17e0edba4e918b1227ea5f39619fc</sys_id>
-        <sys_mod_count>107</sys_mod_count>
+        <sys_mod_count>108</sys_mod_count>
         <sys_name>Eda</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_abc17e0edba4e918b1227ea5f39619fc</sys_update_name>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-08 15:58:56</sys_updated_on>
+        <sys_updated_on>2023-09-08 18:42:41</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f563b62d47152110f39f7601e36d43de.xml
@@ -15,323 +15,321 @@ following locations:&#13;
         <name>HothProvisioning</name>
         <script><![CDATA[const HothProvisioning = Class.create();
 HothProvisioning.prototype = {
-	PORTFOLIO_TABLE: "x_g_dis_atat_portfolio",
-	TASK_ORDER_TABLE: "x_g_dis_atat_task_order",
-	OPERATOR_TABLE: "x_g_dis_atat_operator",
-	CLIN_TABLE: "x_g_dis_atat_clin",
+    PORTFOLIO_TABLE: "x_g_dis_atat_portfolio",
+    TASK_ORDER_TABLE: "x_g_dis_atat_task_order",
+    OPERATOR_TABLE: "x_g_dis_atat_operator",
+    CLIN_TABLE: "x_g_dis_atat_clin",
 
-	portfolio: null,
-	errUtil: new ErrorHandler(),
+    portfolio: null,
+    errUtil: new ErrorHandler(),
 
-	initialize: function(portfolioRecord) {
-		if (!portfolioRecord) {
-			throw this.errUtil.createError(
-				"Portfolio must not be null.",
-				this.errUtil.INVALID_INPUT
-			);
-		}
-		else {
-			this.portfolio = portfolioRecord;
-		}
-	},
+    initialize: function(portfolioRecord) {
+        if (!portfolioRecord) {
+            throw this.errUtil.createError(
+                "Portfolio must not be null.",
+                this.errUtil.INVALID_INPUT
+            );
+        } else {
+            this.portfolio = portfolioRecord;
+        }
+    },
 
-	/**
-   * Truncates the days from Date Strings. Temporarily needed because of a mistaken change in the ATAT 1.1.0 specification.
-   *
-   * @param {string} YYYY-MM-DD formatted Date String
-   * @return {string} YYYY-MM formatted Date String
-   */	
-	truncateDayFromDate: function(date) {
-		if (date && date.length >= 7) {
-			return date.substring(0,7);
-		}
-		else {
-			return date;
-		}
-	},
+    /**
+     * Truncates the days from Date Strings. Temporarily needed because of a mistaken change in the ATAT 1.1.0 specification.
+     *
+     * @param {string} YYYY-MM-DD formatted Date String
+     * @return {string} YYYY-MM formatted Date String
+     */
+    truncateDayFromDate: function(date) {
+        if (date && date.length >= 7) {
+            return date.substring(0, 7);
+        } else {
+            return date;
+        }
+    },
 
-	/**
-   * Converts a SNOW-formatted Date into a HOTH-formatted Date
-   *
-   * @param {string} snowClassification
-   * @return {string} HOTH-formatted Date
-   */
-	convertClassificationToHothFormat: function(snowClassification) {
-		const classificationMap = {
-			U: "UNCLASSIFIED",
-			S: "SECRET",
-			TS: "TOP_SECRET"
-		};
-		return classificationMap[snowClassification];		
-	},
+    /**
+     * Converts a SNOW-formatted Date into a HOTH-formatted Date
+     *
+     * @param {string} snowClassification
+     * @return {string} HOTH-formatted Date
+     */
+    convertClassificationToHothFormat: function(snowClassification) {
+        const classificationMap = {
+            U: "UNCLASSIFIED",
+            S: "SECRET",
+            TS: "TOP_SECRET"
+        };
+        return classificationMap[snowClassification];
+    },
 
-	/**
-   * Converts a HOTH-formatted Date into a SNOW-formatted Date
-   *
-   * @param {string} hothClassification
-   * @return {string} SNOW-formatted Date
-   */	
-	convertClassificationToSnowFormat: function(hothClassification) {
-		const classificationMap = {
-			"UNCLASSIFIED" : "U",
-			"SECRET": "S",
-			"TOP_SECRET": "TS"
-		};
-		return classificationMap[hothClassification];
-	},	
+    /**
+     * Converts a HOTH-formatted Date into a SNOW-formatted Date
+     *
+     * @param {string} hothClassification
+     * @return {string} SNOW-formatted Date
+     */
+    convertClassificationToSnowFormat: function(hothClassification) {
+        const classificationMap = {
+            "UNCLASSIFIED": "U",
+            "SECRET": "S",
+            "TOP_SECRET": "TS"
+        };
+        return classificationMap[hothClassification];
+    },
 
-	/**
-   * Get all CLINs associated with a Task Order
-   *
-   * @param {string} taskOrderSysId
-   * @return {Object[]} an array of CLINs
-   */
-	getClins: function(taskOrderSysId) {
-		try {
-			const scope = this;
+    /**
+     * Get all CLINs associated with a Task Order
+     *
+     * @param {string} taskOrderSysId
+     * @return {Object[]} an array of CLINs
+     */
+    getClins: function(taskOrderSysId) {
+        try {
+            const scope = this;
 
-			let clins = [];
-			const clinRecord = new GlideRecord(this.CLIN_TABLE);
-			clinRecord.addQuery("task_order", taskOrderSysId);
-			clinRecord.query();
-			while (clinRecord.hasNext()) {
-				clinRecord.next();
-				clins.push({
-					clin_number: clinRecord.clin_number.toString(),
-					pop_start_date: clinRecord.pop_start_date.toString(),
-					pop_end_date: clinRecord.pop_end_date.toString(),
-					classification_level: clinRecord.classification_level.toString(),
-					type: clinRecord.type.toString()
-				});
-			}
-			return clins.map(removeSysId)
-				.map(function(clin) {				
-				clin.classification_level = scope.convertClassificationToHothFormat(clin.classification_level);
-				// START DATE FIX
-				// REMOVE THIS (once we add days back to the CLIN date format in the ATAT spec)
-				clin.pop_start_date = scope.truncateDayFromDate(clin.pop_start_date);				
-				clin.pop_end_date = scope.truncateDayFromDate(clin.pop_end_date);
-				// END DATE FIX
-				return clin;
-			});
-		} catch (error) {
-			throw this.errUtil.createError(
-				"HothProvisioning --> getClins(): " + error,
-				this.errUtil.METHOD_ERROR
-			);
-		}
-	},
+            let clins = [];
+            const clinRecord = new GlideRecord(this.CLIN_TABLE);
+            clinRecord.addQuery("task_order", taskOrderSysId);
+            clinRecord.query();
+            while (clinRecord.hasNext()) {
+                clinRecord.next();
+                clins.push({
+                    clin_number: clinRecord.clin_number.toString(),
+                    pop_start_date: clinRecord.pop_start_date.toString(),
+                    pop_end_date: clinRecord.pop_end_date.toString(),
+                    classification_level: clinRecord.classification_level.toString(),
+                    type: clinRecord.type.toString()
+                });
+            }
+            return clins.map(removeSysId)
+                .map(function(clin) {
+                    clin.classification_level = scope.convertClassificationToHothFormat(clin.classification_level);
+                    // START DATE FIX
+                    // REMOVE THIS (once we add days back to the CLIN date format in the ATAT spec)
+                    clin.pop_start_date = scope.truncateDayFromDate(clin.pop_start_date);
+                    clin.pop_end_date = scope.truncateDayFromDate(clin.pop_end_date);
+                    // END DATE FIX
+                    return clin;
+                });
+        } catch (error) {
+            throw this.errUtil.createError(
+                "HothProvisioning --> getClins(): " + error,
+                this.errUtil.METHOD_ERROR
+            );
+        }
+    },
 
-	/**
-   * Get all Task Orders associated with a Portfolio
-   *
-   * @return {Object[]} an array of task orders 
-   */
-	getTaskOrders: function() {
-		try {
-			let taskOrders = [];
-			const taskOrderRecords = new GlideRecord(this.TASK_ORDER_TABLE);
-			taskOrderRecords.addQuery("portfolio", this.portfolio.sys_id.toString());
-			taskOrderRecords.query();
+    /**
+     * Get all Task Orders associated with a Portfolio
+     *
+     * @return {Object[]} an array of task orders 
+     */
+    getTaskOrders: function() {
+        try {
+            let taskOrders = [];
+            const taskOrderRecords = new GlideRecord(this.TASK_ORDER_TABLE);
+            taskOrderRecords.addQuery("portfolio", this.portfolio.sys_id.toString());
+            taskOrderRecords.query();
 
-			while (taskOrderRecords.next()) {
-				// Get Task Order CLINs
-				const taskOrderClins = this.getClins(taskOrderRecords.sys_id.toString());		
+            while (taskOrderRecords.next()) {
+                // Get Task Order CLINs
+                const taskOrderClins = this.getClins(taskOrderRecords.sys_id.toString());
 
-				// Gather Task Orders for a given Portfolio
-				taskOrders.push({
-					taskOrderNumber: taskOrderRecords.task_order_number.toString(),
-					popStartDate: this.truncateDayFromDate(taskOrderRecords.pop_start_date.toString()),
-					popEndDate: this.truncateDayFromDate(taskOrderRecords.pop_end_date.toString()),
-					clins: taskOrderClins,
-				});
-			}		
+                // Gather Task Orders for a given Portfolio
+                taskOrders.push({
+                    taskOrderNumber: taskOrderRecords.task_order_number.toString(),
+                    popStartDate: this.truncateDayFromDate(taskOrderRecords.pop_start_date.toString()),
+                    popEndDate: this.truncateDayFromDate(taskOrderRecords.pop_end_date.toString()),
+                    clins: taskOrderClins,
+                });
+            }
 
-			return taskOrders;
-		} catch (error) {
-			throw this.errUtil.createError(
-				"HothProvisioning --> getTaskOrders(): " + error,
-				this.errUtil.METHOD_ERROR
-			);
-		}
-	},
+            return taskOrders;
+        } catch (error) {
+            throw this.errUtil.createError(
+                "HothProvisioning --> getTaskOrders(): " + error,
+                this.errUtil.METHOD_ERROR
+            );
+        }
+    },
 
-	/**
-   * Get Task Order with a provided TaskOrderNumber
-   *
-   * @param {string} taskOrderSysId
-   * @return {Object[]} an array of task orders 
-   */
-	getTaskOrder: function(taskOrderSysId) {
-		try {
-			const taskOrderRecord = new GlideRecord(this.TASK_ORDER_TABLE);
-			taskOrderRecord.get(taskOrderSysId);
-			if (taskOrderRecord !== undefined) {
-				// Get Task Order CLINs
-				const taskOrderClins = this.getClins(taskOrderSysId);		
+    /**
+     * Get Task Order with a provided TaskOrderNumber
+     *
+     * @param {string} taskOrderSysId
+     * @return {Object[]} an array of task orders 
+     */
+    getTaskOrder: function(taskOrderSysId) {
+        try {
+            const taskOrderRecord = new GlideRecord(this.TASK_ORDER_TABLE);
+            taskOrderRecord.get(taskOrderSysId);
+            if (taskOrderRecord !== undefined) {
+                // Get Task Order CLINs
+                const taskOrderClins = this.getClins(taskOrderSysId);
 
-				// Gather Task Orders for a given Portfolio
-				return {
-					taskOrderNumber: taskOrderRecord.task_order_number.toString(),
-					popStartDate: this.truncateDayFromDate(taskOrderRecord.pop_start_date.toString()),
-					popEndDate: this.truncateDayFromDate(taskOrderRecord.pop_end_date.toString()),
-					clins: taskOrderClins,
-				};
-			}
-		} catch (error) {
-			throw this.errUtil.createError(
-				"HothProvisioning --> getTaskOrder(): " + error,
-				this.errUtil.METHOD_ERROR
-			);
-		}
-	},
+                // Gather Task Orders for a given Portfolio
+                return {
+                    taskOrderNumber: taskOrderRecord.task_order_number.toString(),
+                    popStartDate: this.truncateDayFromDate(taskOrderRecord.pop_start_date.toString()),
+                    popEndDate: this.truncateDayFromDate(taskOrderRecord.pop_end_date.toString()),
+                    clins: taskOrderClins,
+                    csp_id: taskOrderRecord.csp_id ? taskOrderRecord.csp_id.toString() : ""
+                };
+            }
+        } catch (error) {
+            throw this.errUtil.createError(
+                "HothProvisioning --> getTaskOrder(): " + error,
+                this.errUtil.METHOD_ERROR
+            );
+        }
+    },
 
-	/**
-  * Construct a request to provision a Portfolio using the HOTH API.
-  *
-  * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
-  * @param {string} targetCsp - the CSP being targeted for this provision request
-  * @return {Object} an object for provisioning a portfolio
-  * 
-  */
-	createAddPortfolioPayload: function(hothId, targetCsp) {
-		try {
-			if (!hothId || !targetCsp) {
-				throw this.errUtil.createError(
-					"hothId and targetCsp must be provided.",
-					this.errUtil.INVALID_INPUT
-				);
-			}
+    /**
+     * Construct a request to provision a Portfolio using the HOTH API.
+     *
+     * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
+     * @param {string} targetCsp - the CSP being targeted for this provision request
+     * @return {Object} an object for provisioning a portfolio
+     * 
+     */
+    createAddPortfolioPayload: function(hothId, targetCsp) {
+        try {
+            if (!hothId || !targetCsp) {
+                throw this.errUtil.createError(
+                    "hothId and targetCsp must be provided.",
+                    this.errUtil.INVALID_INPUT
+                );
+            }
 
-			const taskOrders = this.getTaskOrders(this.portfolio.sys_id.toString());
+            const taskOrders = this.getTaskOrders(this.portfolio.sys_id.toString());
 
-			return {
-				jobId: hothId,
-				userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
-				operationType: "ADD_PORTFOLIO",
-				targetCspName: targetCsp, 
-				payload: {
-					name: this.portfolio.name.toString(),
-					taskOrders: taskOrders,
-				},
-			};
+            return {
+                jobId: hothId,
+                userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
+                operationType: "ADD_PORTFOLIO",
+                targetCspName: targetCsp,
+                payload: {
+                    name: this.portfolio.name.toString(),
+                    taskOrders: taskOrders,
+                },
+            };
 
-		} catch (error) {
-			const errorMessage = "Error creating an Add Portfolio payload. " + error;
-			this.errUtil.createError(
-				errorMessage,
-				this.errUtil.INVALID_INPUT
-			);
-		}
-	},
+        } catch (error) {
+            const errorMessage = "Error creating an Add Portfolio payload. " + error;
+            this.errUtil.createError(
+                errorMessage,
+                this.errUtil.INVALID_INPUT
+            );
+        }
+    },
 
-	/**
-   * Construct a request to provision an Environment using the HOTH API.
-   *
-   * @param {string} environmentRecord - the Environment being provisioned
-   * @return {Object} a valid ADD_ENVIRONMENT Provisioning Job Payload
-   * 
-   */
-	createAddEnvironmentPayload: function(environmentRecord) {
-		if (!environmentRecord) {
-			throw this.errUtil.createError(
-				"Environment must not be null.",
-				this.errUtil.INVALID_INPUT
-			);
-		}
+    /**
+     * Construct a request to provision an Environment using the HOTH API.
+     *
+     * @param {string} environmentRecord - the Environment being provisioned
+     * @return {Object} a valid ADD_ENVIRONMENT Provisioning Job Payload
+     * 
+     */
+    createAddEnvironmentPayload: function(environmentRecord) {
+        if (!environmentRecord) {
+            throw this.errUtil.createError(
+                "Environment must not be null.",
+                this.errUtil.INVALID_INPUT
+            );
+        }
 
-		const scope = this;
-		const hothClassificationLevel = this.convertClassificationToHothFormat(environmentRecord.classification_level.toString());
-		const jobPayload = {
-			jobId: gs.generateGUID(),
-			userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
-			operationType: "ADD_ENVIRONMENT",
-			targetCspName: environmentRecord.csp.name.toString(), 
-			portfolioId: this.portfolio.csp_id.toString(),
-			payload: {
-				name: environmentRecord.name.toString(),				
-				classificationLevel: hothClassificationLevel,
-				cloudDistinguisher: environmentRecord.csp.cloud_distinguisher ? JSON.parse(environmentRecord.csp.cloud_distinguisher) : null,
-				administrators: environmentRecord.pending_operators ? 
-				environmentRecord.pending_operators.toString().split(",")
-				.map(function (operatorSysId) {
-					const record = new GlideRecord(scope.OPERATOR_TABLE);
-					record.get(operatorSysId);
-					return {
-						email: record.email.toString(),
-						dodId: record.dod_id.toString()				
-					};
-				})
-				: null
-			},
-		};
-		if (environmentRecord.csp.cloudDistinguisher) {
-			jobPayload.payload.cloudDistinguisher = environmentRecord.csp.cloudDistinguisher;
-		}
-		return jobPayload;
-	},	
+        const scope = this;
+        const hothClassificationLevel = this.convertClassificationToHothFormat(environmentRecord.classification_level.toString());
+        const jobPayload = {
+            jobId: gs.generateGUID(),
+            userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
+            operationType: "ADD_ENVIRONMENT",
+            targetCspName: environmentRecord.csp.name.toString(),
+            portfolioId: this.portfolio.csp_id.toString(),
+            payload: {
+                name: environmentRecord.name.toString(),
+                classificationLevel: hothClassificationLevel,
+                cloudDistinguisher: environmentRecord.csp.cloud_distinguisher ? JSON.parse(environmentRecord.csp.cloud_distinguisher) : null,
+                administrators: environmentRecord.pending_operators ?
+                    environmentRecord.pending_operators.toString().split(",")
+                    .map(function(operatorSysId) {
+                        const record = new GlideRecord(scope.OPERATOR_TABLE);
+                        record.get(operatorSysId);
+                        return {
+                            email: record.email.toString(),
+                            dodId: record.dod_id.toString()
+                        };
+                    }) :
+                    null
+            },
+        };
+        if (environmentRecord.csp.cloudDistinguisher) {
+            jobPayload.payload.cloudDistinguisher = environmentRecord.csp.cloudDistinguisher;
+        }
+        return jobPayload;
+    },
 
-	/**
-  * Construct a request to update a TaskOrder using the HOTH API.
-  *
-  * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
-  * @param {string} targetCsp - the CSP being targeted for this provision request
-  * @param {string} taskOrderSysId - the sys_id of the task order record within ServiceNow
-  * @return {Object} an object for updating a task order
-  * 
-  */
-	createUpdateTaskOrderPayload: function(hothId, targetCsp, taskOrderSysId) {
-		try {
-			if (!hothId || !targetCsp) {
-				throw this.errUtil.createError(
-					"hothId and targetCsp must be provided.",
-					this.errUtil.INVALID_INPUT
-				);
-			}
+    /**
+     * Construct a request to update a TaskOrder using the HOTH API.
+     *
+     * @param {string} hothId - a GUID generated within ServiceNow for the provisioning job
+     * @param {string} targetCsp - the CSP being targeted for this provision request
+     * @param {string} taskOrderSysId - the sys_id of the task order record within ServiceNow
+     * @return {Object} an object for updating a task order
+     * 
+     */
+    createUpdateTaskOrderPayload: function(hothId, targetCsp, taskOrderSysId) {
+        try {
+            if (!hothId || !targetCsp) {
+                throw this.errUtil.createError(
+                    "hothId and targetCsp must be provided.",
+                    this.errUtil.INVALID_INPUT
+                );
+            }
 
-			const taskOrder = this.getTaskOrder(taskOrderSysId.toString());
-			gs.info("createUpdateTaskOrderPayload => " + JSON.stringify(taskOrder));
-			if (!taskOrder.csp_id) {
-				throw this.errUtil.createError(
-					"taskOrder must have a valid CSP ID to update.",
-					this.errUtil.INVALID_INPUT
-				);
-			}
+            const taskOrder = this.getTaskOrder(taskOrderSysId.toString());
+            if (!taskOrder.csp_id) {
+                throw this.errUtil.createError(
+                    "taskOrder must have a valid CSP ID to update.",
+                    this.errUtil.INVALID_INPUT
+                );
+            }
 
-			return {
-				jobId: hothId,
-				userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
-				operationType: "UPDATE_TASK_ORDER",
-				targetCspName: targetCsp.toString(), 
-				payload: {
-					portfolioId: this.portfolio.csp_id ? this.portfolio.csp_id.toString() : "",
-					taskOrderId: taskOrder.csp_id ? taskOrder.csp_id.toString() : "",
-					taskOrder: taskOrder,
-				},
-			};
+            return {
+                jobId: hothId,
+                userId: this.portfolio.portfolio_managers ? this.portfolio.portfolio_managers.split(",")[0] : "",
+                operationType: "UPDATE_TASK_ORDER",
+                targetCspName: targetCsp.toString(),
+                portfolioId: this.portfolio.csp_id ? this.portfolio.csp_id.toString() : "",
+                payload: {
+                    taskOrderId: taskOrder.csp_id ? taskOrder.csp_id.toString() : "",
+                    taskOrder: taskOrder,
+                },
+            };
 
-		} catch (error) {
-			const errorMessage = "Error creating an Update TaskOrder payload. " + error;
-			this.errUtil.createError(
-				errorMessage,
-				this.errUtil.INVALID_INPUT
-			);
-		}
-	},
+        } catch (error) {
+            const errorMessage = "Error creating an Update TaskOrder payload. " + error;
+            this.errUtil.createError(
+                errorMessage,
+                this.errUtil.INVALID_INPUT
+            );
+        }
+    },
 
-	type: 'HothProvisioning'
+    type: 'HothProvisioning'
 };]]></script>
         <sys_class_name>sys_script_include</sys_class_name>
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2023-02-28 20:22:38</sys_created_on>
         <sys_id>f563b62d47152110f39f7601e36d43de</sys_id>
-        <sys_mod_count>63</sys_mod_count>
+        <sys_mod_count>67</sys_mod_count>
         <sys_name>HothProvisioning</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_f563b62d47152110f39f7601e36d43de</sys_update_name>
-        <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-07 22:52:24</sys_updated_on>
+        <sys_updated_by>1609291318.CTR</sys_updated_by>
+        <sys_updated_on>2023-09-08 17:51:52</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_1946bd8edb64a918b1227ea5f396197f.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_1946bd8edb64a918b1227ea5f396197f.xml
@@ -21,6 +21,7 @@
                 message: message
             }));	
 		}
+		return toDetails;
 	} catch (e) {
 		gs.error(e);		
 		response.setStatus(400);
@@ -46,14 +47,14 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-01-23 22:23:16</sys_created_on>
         <sys_id>1946bd8edb64a918b1227ea5f396197f</sys_id>
-        <sys_mod_count>45</sys_mod_count>
+        <sys_mod_count>46</sys_mod_count>
         <sys_name>Get Task Order Details</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_ws_operation_1946bd8edb64a918b1227ea5f396197f</sys_update_name>
         <sys_updated_by>xander.keele</sys_updated_by>
-        <sys_updated_on>2023-09-08 15:56:16</sys_updated_on>
+        <sys_updated_on>2023-09-08 18:42:03</sys_updated_on>
         <web_service_definition display_value="Provisioning">4ba165cadb6c6918b1227ea5f39619e4</web_service_definition>
         <web_service_version/>
     </sys_ws_operation>


### PR DESCRIPTION
Ensuring handling of empty `csp_id` is correct. Moved `portfolioId` outside of payload object.

Added `csp_id` as part of the `getTaskOrder` function to be available to the `createUpdateTaskOrderPayload` function.
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/aff22059-acde-4b18-81da-bf60703084a1)

Moved `portfolioId` outside of `payload` object
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/c0791e02-5aab-4d23-8b33-656d37104581)
