### PR TITLE
added two manual calls to GlideRecord.update() to enforce database sy…

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
@@ -561,7 +561,7 @@ Eda.prototype = {
         environmentRecord.setValue("portfolio", portfolio.sys_id);
         environmentRecord.setValue("csp", cspRecord.sys_id);
         environmentRecord.setValue("classification_level", cspRecord.classification_level);
-        environmentRecord.setValue("environment_status", "PROCESSING");
+        
         environmentRecord.insert();
 
         // Update Portfolio Vendor
@@ -577,11 +577,13 @@ Eda.prototype = {
             operatorRecord.setValue("email", operator.email);
             operatorRecord.setValue("portfolio", portfolio.sys_id);
             operatorRecord.setValue("environment", environmentRecord.sys_id);
+			operatorRecord.update();
             pendingOperators.push(operatorRecord.insert());
         });
 
         // Add Operators back to Environment
         environmentRecord.setValue("pending_operators", pendingOperators);
+		environmentRecord.setValue("environment_status", "PROCESSING");
         environmentRecord.update();
     },
 
@@ -652,13 +654,13 @@ Eda.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-01-24 02:42:04</sys_created_on>
         <sys_id>abc17e0edba4e918b1227ea5f39619fc</sys_id>
-        <sys_mod_count>109</sys_mod_count>
+        <sys_mod_count>110</sys_mod_count>
         <sys_name>Eda</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_abc17e0edba4e918b1227ea5f39619fc</sys_update_name>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-11 15:38:27</sys_updated_on>
+        <sys_updated_by>stephen.hayes</sys_updated_by>
+        <sys_updated_on>2023-09-13 22:31:20</sys_updated_on>
     </sys_script_include>
 </record_update>


### PR DESCRIPTION
Moved setting environment to PROCESSING until AFTER operator records have been created (line 577)
Added two manual calls to GlideRecord.update() to enforce DB sync in a workflow.

![image](https://github.com/dod-ccpo/atat-snow/assets/137221342/4118b1ce-1940-4794-bff3-6eeb4710144b)
