### PR TITLE
PR 519 - feature/AT-9747-add-working-capital-fund-option

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_appropriation_funds_type.xml
+++ b/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_appropriation_funds_type.xml
@@ -29,6 +29,7 @@
             <sys_created_on>2023-05-05 18:22:16</sys_created_on>
             <sys_domain>global</sys_domain>
             <sys_domain_path>/</sys_domain_path>
+            <sys_id>06915dd74759b1109053e4be436d43f2</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_updated_by>admin</sys_updated_by>
             <sys_updated_on>2023-05-05 18:22:16</sys_updated_on>
@@ -48,6 +49,7 @@
             <sys_created_on>2023-05-08 13:06:12</sys_created_on>
             <sys_domain>global</sys_domain>
             <sys_domain_path>/</sys_domain_path>
+            <sys_id>c2915dd74759b1109053e4be436d43f3</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_updated_by>admin</sys_updated_by>
             <sys_updated_on>2023-05-08 13:06:12</sys_updated_on>
@@ -67,6 +69,7 @@
             <sys_created_on>2023-05-08 13:07:00</sys_created_on>
             <sys_domain>global</sys_domain>
             <sys_domain_path>/</sys_domain_path>
+            <sys_id>82915dd74759b1109053e4be436d43f4</sys_id>
             <sys_mod_count>2</sys_mod_count>
             <sys_updated_by>admin</sys_updated_by>
             <sys_updated_on>2023-05-08 13:07:15</sys_updated_on>
@@ -86,10 +89,31 @@
             <sys_created_on>2023-05-08 13:06:34</sys_created_on>
             <sys_domain>global</sys_domain>
             <sys_domain_path>/</sys_domain_path>
+            <sys_id>42915dd74759b1109053e4be436d43f5</sys_id>
             <sys_mod_count>0</sys_mod_count>
             <sys_updated_by>admin</sys_updated_by>
             <sys_updated_on>2023-05-08 13:06:34</sys_updated_on>
             <value>RDT_E</value>
+        </sys_choice>
+        <sys_choice action="INSERT_OR_UPDATE">
+            <dependent_value/>
+            <element>appropriation_funds_type</element>
+            <hint/>
+            <inactive>false</inactive>
+            <label>Working Capital</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request</name>
+            <sequence/>
+            <synonyms/>
+            <sys_created_by>andrew.nickerl</sys_created_by>
+            <sys_created_on>2023-09-20 20:19:29</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>bfd7191b4759b1109053e4be436d4360</sys_id>
+            <sys_mod_count>1</sys_mod_count>
+            <sys_updated_by>andrew.nickerl</sys_updated_by>
+            <sys_updated_on>2023-09-20 20:19:33</sys_updated_on>
+            <value>W_C</value>
         </sys_choice>
     </sys_choice>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request.xml
@@ -7,6 +7,7 @@
                 <element inactive_on_update="false" label="Operations &amp; Maintenance" value="O_M"/>
                 <element inactive_on_update="false" label="Procurement" value="PROCUREMENT"/>
                 <element inactive_on_update="false" label="Research, Development, Test &amp; Evaluation" value="RDT_E"/>
+                <element inactive_on_update="false" label="Working Capital" value="W_C"/>
             </choice>
         </element>
         <element label="FS Form" max_length="32" name="fs_form" reference="x_g_dis_atat_funding_request_fs_form" type="reference"/>


### PR DESCRIPTION
Adds "Working Capital" as a choice on the Appropriation Funds Type column of the FundingRequests table.

See corresponding UI PR here:  https://github.com/dod-ccpo/atat-web-ui/pull/1972

![Screenshot 2023-09-20 at 2 02 27 PM](https://github.com/dod-ccpo/atat-snow/assets/135259059/6e592c38-7485-444c-b3d5-67d5d0735abe)
