### PR TITLE
feature/AT-9605-leave-portfolio

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_a0ff1bf42fd15110e58359a72799b63b.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_a0ff1bf42fd15110e58359a72799b63b.xml
@@ -10,13 +10,13 @@
         <copied_from_name/>
         <description>Queues initial portfolio provisioning job when 1) at least one Operator has been assigned and 2) EDA validation has been performed on the associated Task Order</description>
         <internal_name>queue_initial_portfolio_provisioning_job</internal_name>
-        <label_cache>[{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Table","label":"2 - Look Up Record➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Record","label":"2 - Look Up Record➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Table","label":"2 - Look Up Record➛ATAT:Environment Table","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record","label":"2 - Look Up Record➛ATAT:Environment Record","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record.csp.vendor","label":"2 - Look Up Record➛ATAT:Environment Record➛CSP➛Vendor","reference":"","reference_display":"Vendor","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_cloud_service_provider","column_name":"vendor","choices":[{"label":"Amazon Web Services","image":"","reference":false,"used":false,"rawLabel":"Amazon Web Services","selected":false,"missing":false,"value":"AWS","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Google Cloud Platform","image":"","reference":false,"used":false,"rawLabel":"Google Cloud Platform","selected":false,"missing":false,"value":"GCP","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Microsoft Azure","image":"","reference":false,"used":false,"rawLabel":"Microsoft Azure","selected":false,"missing":false,"value":"AZURE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Oracle Cloud","image":"","reference":false,"used":false,"rawLabel":"Oracle Cloud","selected":false,"missing":false,"value":"ORACLE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}}]},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__dont_treat_as_error__","label":"6➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__action_status__","label":"6➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.table_name","label":"6➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.record","label":"6➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"6ffc5018-4cdb-4ed7-9a5f-3a5d7c8fa9c7.item","label":"5➛ATAT:Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"Created or Updated_1.current.sys_id","label":"Trigger➛Portfolio Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","image":"","reference":false,"used":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","image":"","reference":false,"used":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","image":"","reference":false,"used":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","image":"","reference":false,"used":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","image":"","reference":false,"used":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.message","label":"5➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"eae4ca7a-5ba6-465c-b7bd-6ba1cf184947"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.status","label":"5➛Status","reference_display":"Status","type":"choice","base_type":"choice","attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"828e2127-df28-4eda-af48-ee4e876cca1e"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"uiType":"integer","uiTypeLabel":"Integer","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"edb3c082-a356-4943-a263-55232fc02390"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Table","label":"5➛ATAT:Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Records","label":"5➛ATAT:Operator Records","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.run_start_time","label":"Trigger➛Run Start Time","type":"glide_date_time","base_type":"glide_date_time","attributes":{"test_input_hidden":"true"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__dont_treat_as_error__","label":"4 - Update Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__action_status__","label":"4 - Update Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.table_name","label":"4 - Update Record➛ATAT:Portfolio Table","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.record","label":"4 - Update Record➛ATAT:Portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__dont_treat_as_error__","label":"3 - Log➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__action_status__","label":"3 - Log➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.operators","label":"Trigger➛Portfolio Record➛Pending Operators","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"glide_list","base_type":"glide_list","parent_table_name":"x_g_dis_atat_portfolio","column_name":"operators"},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Count","label":"1➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Table","label":"1➛CLIN Table","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Records","label":"1➛CLIN Records","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"8359b0e6-638d-450a-809c-b2ec5bf3a034.item","label":"2➛Items","reference_display":"Items","type":"document_id","base_type":"document_id","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.record","label":"1➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.table_name","label":"1➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.table_name","label":"2 - Create Record➛ATAT:Provisioning Job Table","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__action_status__","label":"2 - Create Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__dont_treat_as_error__","label":"2 - Create Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{}},{"name":"Created or Updated_1.current.acquisition_package","label":"Trigger➛Portfolio Record➛Acquisition Package","reference":"x_g_dis_atat_acquisition_package","reference_display":"DAPPS:Acquisition Package","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_portfolio","column_name":"acquisition_package"},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.record","label":"5➛Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.table_name","label":"5➛Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"2ade410f-636d-4f9a-b67a-c121b6332e69"}}]</label_cache>
+        <label_cache>[{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"2ade410f-636d-4f9a-b67a-c121b6332e69"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.table_name","label":"5➛Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.record","label":"5➛Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.acquisition_package","label":"Trigger➛Portfolio Record➛Acquisition Package","reference":"x_g_dis_atat_acquisition_package","reference_display":"DAPPS:Acquisition Package","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_portfolio","column_name":"acquisition_package"},{"name":"Created or Updated_1.current","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__dont_treat_as_error__","label":"2 - Create Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__action_status__","label":"2 - Create Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.table_name","label":"2 - Create Record➛ATAT:Provisioning Job Table","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.table_name","label":"1➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.record","label":"1➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"8359b0e6-638d-450a-809c-b2ec5bf3a034.item","label":"2➛Items","reference_display":"Items","type":"document_id","base_type":"document_id","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Records","label":"1➛CLIN Records","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Table","label":"1➛CLIN Table","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Count","label":"1➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.operators","label":"Trigger➛Portfolio Record➛Pending Operators","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"glide_list","base_type":"glide_list","parent_table_name":"x_g_dis_atat_portfolio","column_name":"operators"},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__action_status__","label":"3 - Log➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__dont_treat_as_error__","label":"3 - Log➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.record","label":"4 - Update Record➛ATAT:Portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.table_name","label":"4 - Update Record➛ATAT:Portfolio Table","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__action_status__","label":"4 - Update Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__dont_treat_as_error__","label":"4 - Update Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.run_start_time","label":"Trigger➛Run Start Time","type":"glide_date_time","base_type":"glide_date_time","attributes":{"test_input_hidden":"true"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Records","label":"5➛ATAT:Operator Records","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Table","label":"5➛ATAT:Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"uiType":"integer","uiTypeLabel":"Integer","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"edb3c082-a356-4943-a263-55232fc02390"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.status","label":"5➛Status","reference_display":"Status","type":"choice","base_type":"choice","attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"828e2127-df28-4eda-af48-ee4e876cca1e"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.message","label":"5➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"eae4ca7a-5ba6-465c-b7bd-6ba1cf184947"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Created or Updated_1.current.sys_id","label":"Trigger➛Portfolio Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"6ffc5018-4cdb-4ed7-9a5f-3a5d7c8fa9c7.item","label":"5➛ATAT:Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.record","label":"6➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.table_name","label":"6➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__action_status__","label":"6➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__dont_treat_as_error__","label":"6➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record.csp.vendor","label":"2 - Look Up Record➛ATAT:Environment Record➛CSP➛Vendor","reference":"","reference_display":"Vendor","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_cloud_service_provider","column_name":"vendor","choices":[{"label":"Amazon Web Services","used":false,"image":"","reference":false,"rawLabel":"Amazon Web Services","selected":false,"missing":false,"value":"AWS","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Google Cloud Platform","used":false,"image":"","reference":false,"rawLabel":"Google Cloud Platform","selected":false,"missing":false,"value":"GCP","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Microsoft Azure","used":false,"image":"","reference":false,"rawLabel":"Microsoft Azure","selected":false,"missing":false,"value":"AZURE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Oracle Cloud","used":false,"image":"","reference":false,"rawLabel":"Oracle Cloud","selected":false,"missing":false,"value":"ORACLE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}}]},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record","label":"2 - Look Up Record➛ATAT:Environment Record","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Table","label":"2 - Look Up Record➛ATAT:Environment Table","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Record","label":"2 - Look Up Record➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Table","label":"2 - Look Up Record➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
         <master_snapshot>99d63b37dbb619d0b1227ea5f396190e</master_snapshot>
         <name>PROV: Queue Initial Portfolio Provisioning Job</name>
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id>a450ec559715f1105e3a797e6253afaf</remote_trigger_id>
+        <remote_trigger_id>25d222a39755311084aaf8a6f053afb0</remote_trigger_id>
         <run_as>user</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
@@ -29,7 +29,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>a0ff1bf42fd15110e58359a72799b63b</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>15</sys_mod_count>
         <sys_name>PROV: Queue Initial Portfolio Provisioning Job</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -37,7 +37,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_a0ff1bf42fd15110e58359a72799b63b</sys_update_name>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:12</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=a0ff1bf42fd15110e58359a72799b63b"/>
@@ -61,15 +61,15 @@
         <run_when_user_setting>any</run_when_user_setting>
         <sys_class_name>sys_flow_record_trigger</sys_class_name>
         <sys_created_by>admin</sys_created_by>
-        <sys_created_on>2023-09-14 11:08:37</sys_created_on>
+        <sys_created_on>2023-09-21 20:25:11</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
-        <sys_id>a450ec559715f1105e3a797e6253afaf</sys_id>
+        <sys_id>25d222a39755311084aaf8a6f053afb0</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_overrides/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <table>x_g_dis_atat_portfolio</table>
     </sys_flow_record_trigger>
     <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
@@ -78,14 +78,14 @@
         <identifier>a0ff1bf42fd15110e58359a72799b63b</identifier>
         <runner>FDTriggerRunner</runner>
         <sys_created_by>admin</sys_created_by>
-        <sys_created_on>2023-09-14 11:08:37</sys_created_on>
-        <sys_id>2050ec559715f1105e3a797e6253afb0</sys_id>
+        <sys_created_on>2023-09-21 20:25:11</sys_created_on>
+        <sys_id>add222a39755311084aaf8a6f053afb0</sys_id>
         <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
-        <trigger display_value="">a450ec559715f1105e3a797e6253afaf</trigger>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
+        <trigger display_value="">25d222a39755311084aaf8a6f053afb0</trigger>
     </sys_trigger_runner_mapping>
-    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN2050ec559715f1105e3a797e6253afb0"/>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT INadd222a39755311084aaf8a6f053afb0"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN8650eff42fd15110e58359a72799b657"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -96,10 +96,10 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 19:28:19</sys_created_on>
         <sys_id>8650eff42fd15110e58359a72799b657</sys_id>
-        <sys_mod_count>81</sys_mod_count>
+        <sys_mod_count>100</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -114,10 +114,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-09-13 18:10:03</sys_created_on>
         <sys_id>083770854795bd50f6b8f0bd436d4319</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-13 18:10:03</sys_updated_on>
-        <value>unique_changes</value>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-21 20:21:38</sys_updated_on>
+        <value>once</value>
         <variable display_value="Run Trigger">2b9def50c31132002841b63b12d3ae5b</variable>
     </sys_variable_value>
     <sys_variable_value action="INSERT_OR_UPDATE">
@@ -128,9 +128,9 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 19:28:19</sys_created_on>
         <sys_id>4a50eff42fd15110e58359a72799b658</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>8</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:17</sys_updated_on>
+        <sys_updated_on>2023-09-21 18:54:07</sys_updated_on>
         <value>portfolio_ownerISNOTEMPTY^provisioned=false^active_task_orderISNOTEMPTY^active_task_order.clinsISNOTEMPTY^csp_idISEMPTY</value>
         <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
     </sys_variable_value>
@@ -227,14 +227,14 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 19:28:19</sys_created_on>
         <sys_id>35506ff42fd15110e58359a72799b65e</sys_id>
-        <sys_mod_count>23</sys_mod_count>
+        <sys_mod_count>35</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -393,14 +393,14 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 19:28:19</sys_created_on>
         <sys_id>7950eff42fd15110e58359a72799b643</sys_id>
-        <sys_mod_count>23</sys_mod_count>
+        <sys_mod_count>35</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -415,7 +415,7 @@
     </sys_hub_flow_input>
     <sys_hub_flow_output action="delete_multiple" query="model=a0ff1bf42fd15110e58359a72799b63b"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=a0ff1bf42fd15110e58359a72799b63b"/>
-    <sys_hub_action_instance action="delete_multiple" query="flow=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN2cbb6b702f155110e58359a72799b618,71833c092fd55110e58359a72799b6ee,9fde1e1597b21110cf3cfd9fe153afea"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN2cbb6b702f155110e58359a72799b618,71833c092fd55110e58359a72799b6ee"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
         <action_inputs/>
         <action_inputs/>
@@ -430,10 +430,10 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 20:17:55</sys_created_on>
         <sys_id>2cbb6b702f155110e58359a72799b618</sys_id>
-        <sys_mod_count>170</sys_mod_count>
+        <sys_mod_count>222</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <ui_id>d9e64b95-55b2-4f05-87ec-763b155a845b</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=2cbb6b702f155110e58359a72799b618"/>
@@ -524,9 +524,9 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-11 20:17:55</sys_created_on>
         <sys_id>a8bb6b702f155110e58359a72799b619</sys_id>
-        <sys_mod_count>27</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-13 18:07:30</sys_updated_on>
+        <sys_mod_count>30</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-21 20:25:02</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=2cbb6b702f155110e58359a72799b618"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -543,10 +543,10 @@
         <sys_created_by>jeff.segal-ctr@ccpo.mil</sys_created_by>
         <sys_created_on>2022-08-12 01:31:45</sys_created_on>
         <sys_id>71833c092fd55110e58359a72799b6ee</sys_id>
-        <sys_mod_count>148</sys_mod_count>
+        <sys_mod_count>200</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <ui_id>454d07c5-33e9-4dd4-9a14-d257befa89a4</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=71833c092fd55110e58359a72799b6ee"/>
@@ -577,175 +577,10 @@
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=71833c092fd55110e58359a72799b6ee"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=71833c092fd55110e58359a72799b6ee"/>
-    <sys_hub_action_instance action="INSERT_OR_UPDATE">
-        <action_inputs/>
-        <action_inputs/>
-        <action_type display_value="Update Record">f9d01dd2c31332002841b63b12d3aea1</action_type>
-        <action_type_parent/>
-        <comment>set status to Processing and record provisioning request date</comment>
-        <display_text/>
-        <flow display_value="PROV: Queue Initial Portfolio Provisioning Job">a0ff1bf42fd15110e58359a72799b63b</flow>
-        <order>4</order>
-        <parent_ui_id/>
-        <sys_class_name>sys_hub_action_instance</sys_class_name>
-        <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-        <sys_created_on>2022-10-26 17:33:23</sys_created_on>
-        <sys_id>9fde1e1597b21110cf3cfd9fe153afea</sys_id>
-        <sys_mod_count>140</sys_mod_count>
-        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
-        <ui_id>7ffd664e-d808-4a1b-9be2-e9c4fde0af19</ui_id>
-    </sys_hub_action_instance>
-    <sys_variable_value action="delete_multiple" query="document_key=9fde1e1597b21110cf3cfd9fe153afea"/>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>9fde1e1597b21110cf3cfd9fe153afea</document_key>
-        <order>100</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:36</sys_created_on>
-        <sys_id>024827a947d52110f39f7601e36d4335</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:36</sys_updated_on>
-        <value>portfolio_status=PROCESSING</value>
-        <variable display_value="Fields">e7d270ccc3c632002841b63b12d3ae8b</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>9fde1e1597b21110cf3cfd9fe153afea</document_key>
-        <order>100</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-02-28 22:52:29</sys_created_on>
-        <sys_id>18a65f2947952110f39f7601e36d43d2</sys_id>
-        <sys_mod_count>4</sys_mod_count>
-        <sys_updated_by>eric.youngquist</sys_updated_by>
-        <sys_updated_on>2023-07-12 14:56:12</sys_updated_on>
-        <value>portfolio_status=PROCESSING^provisioning_request_date=fd-scripted^portfolio_owner=fd-scripted^=</value>
-        <variable display_value="Fields">02d01916c31332002841b63b12d3aeee</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>9fde1e1597b21110cf3cfd9fe153afea</document_key>
-        <order>50</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-        <sys_created_on>2022-10-26 17:33:23</sys_created_on>
-        <sys_id>1bde1e1597b21110cf3cfd9fe153afed</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-10-26 17:33:23</sys_updated_on>
-        <value>x_g_dis_atat_portfolio</value>
-        <variable display_value="Table">b5d01916c31332002841b63b12d3aec9</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>9fde1e1597b21110cf3cfd9fe153afea</document_key>
-        <order>50</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:36</sys_created_on>
-        <sys_id>c24827a947d52110f39f7601e36d4335</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:36</sys_updated_on>
-        <value>x_g_dis_atat_portfolio</value>
-        <variable display_value="Table">1fd27c8cc3c632002841b63b12d3aeb9</variable>
-    </sys_variable_value>
-    <sys_element_mapping action="delete_multiple" query="id=9fde1e1597b21110cf3cfd9fe153afea"/>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>record</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:36</sys_created_on>
-        <sys_id>ca4827a947d52110f39f7601e36d4334</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:36</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value>{{Created or Updated_1.current}}</value>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>record</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-        <sys_created_on>2022-10-26 17:33:23</sys_created_on>
-        <sys_id>d3de1e1597b21110cf3cfd9fe153afed</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-10-26 17:33:23</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value>{{Created or Updated_1.current}}</value>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>table_name</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:36</sys_created_on>
-        <sys_id>0a4827a947d52110f39f7601e36d4334</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:36</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>table_name</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-        <sys_created_on>2022-10-26 17:33:23</sys_created_on>
-        <sys_id>9bde1e1597b21110cf3cfd9fe153afec</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>jason.burkert-ctr@ccpo.mil</sys_updated_by>
-        <sys_updated_on>2022-10-26 17:33:23</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>values</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:36</sys_created_on>
-        <sys_id>8e4827a947d52110f39f7601e36d4334</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:36</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>values</field>
-        <id>9fde1e1597b21110cf3cfd9fe153afea</id>
-        <sys_created_by>jason.burkert-ctr@ccpo.mil</sys_created_by>
-        <sys_created_on>2022-10-26 17:33:23</sys_created_on>
-        <sys_id>97de1e1597b21110cf3cfd9fe153afed</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-02-28 22:52:29</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_hub_input_scripts action="delete_multiple" query="instance=9fde1e1597b21110cf3cfd9fe153afea^sys_idNOT INb6b25af2dbe161548c045e8cd3961943"/>
-    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
-        <active>true</active>
-        <input_name>values</input_name>
-        <instance>9fde1e1597b21110cf3cfd9fe153afea</instance>
-        <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"provisioning_request_date":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**Available options display upon pressing \".\" after fd_data\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nreturn new GlideDateTime().getDisplayValue();","savedValue":""},"portfolio_owner":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**Available options display upon pressing \".\" after fd_data\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nconst createdByUserId \u003d fd_data.trigger.current.sys_created_by;\ngs.info(\"IN FLOW: createdByUserId: \" + createdByUserId)\nconst userGr \u003d new GlideRecord(\u0027sys_user\u0027);\nuserGr.addQuery(\u0027user_name\u0027, createdByUserId);\nuserGr.query();\nif (userGr.next()) {\n    gs.info(\"IN FLOW: user sys_id: \" + userGr.sys_id);\n    return userGr.sys_id;\n} else {\n    throw new Error(`User with ID ${createdByUserId} not found.`);\n}\n","savedValue":""}}</script>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2023-03-17 01:23:55</sys_created_on>
-        <sys_id>b6b25af2dbe161548c045e8cd3961943</sys_id>
-        <sys_mod_count>7</sys_mod_count>
-        <sys_updated_by>eric.youngquist</sys_updated_by>
-        <sys_updated_on>2023-07-12 15:38:37</sys_updated_on>
-    </sys_hub_input_scripts>
-    <sys_hub_alias_mapping action="delete_multiple" query="source_id=9fde1e1597b21110cf3cfd9fe153afea"/>
     <sys_hub_sub_flow_instance action="delete_multiple" query="flow=a0ff1bf42fd15110e58359a72799b63b"/>
     <sys_hub_flow_logic action="delete_multiple" query="flow=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN713812b7dbc7dd508c045e8cd396190f"/>
     <sys_hub_flow_logic action="INSERT_OR_UPDATE">
-        <block display_value="">6f306c559715f1105e3a797e6253af0e</block>
+        <block display_value="">806424179791311084aaf8a6f053af50</block>
         <comment/>
         <connected_to/>
         <decision_table/>
@@ -765,10 +600,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-15 21:44:51</sys_created_on>
         <sys_id>713812b7dbc7dd508c045e8cd396190f</sys_id>
-        <sys_mod_count>62</sys_mod_count>
+        <sys_mod_count>82</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:38</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <ui_id>7bf04fd6-96cc-4cfc-8f4e-fb2d9c1c75ac</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -950,7 +785,7 @@
     <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_a0ff1bf42fd15110e58359a72799b63b"/>
     <sys_flow_trigger_plan action="delete_multiple" query="plan_id=a0ff1bf42fd15110e58359a72799b63b^sys_idNOT IN16d6fb37dbb619d0b1227ea5f3961952"/>
     <sys_flow_trigger_plan action="INSERT_OR_UPDATE">
-        <binding_strategy>com.snc.process_flow.engine.binding.OncePerUniqueChange</binding_strategy>
+        <binding_strategy>com.snc.process_flow.engine.binding.OncePerRecord</binding_strategy>
         <plan>{"persistor":{"@class":".ChunkingPlanPersistor","table":"sys_flow_trigger_plan","id":"16d6fb37dbb619d0b1227ea5f3961952","name":"plan","plan_signature":null}}</plan>
         <plan_id>a0ff1bf42fd15110e58359a72799b63b</plan_id>
         <snapshot>99d63b37dbb619d0b1227ea5f396190e</snapshot>
@@ -959,12 +794,12 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>16d6fb37dbb619d0b1227ea5f3961952</sys_id>
-        <sys_mod_count>11</sys_mod_count>
+        <sys_mod_count>17</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
-        <trigger display_value="">a450ec559715f1105e3a797e6253afaf</trigger>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
+        <trigger display_value="">25d222a39755311084aaf8a6f053afb0</trigger>
     </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=a0ff1bf42fd15110e58359a72799b63b"/>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
@@ -978,7 +813,7 @@
         <copied_from_name/>
         <description>Queues initial portfolio provisioning job when 1) at least one Operator has been assigned and 2) EDA validation has been performed on the associated Task Order</description>
         <internal_name>prov_queue_initial_portfolio_provisioning_job</internal_name>
-        <label_cache>[{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Table","label":"2 - Look Up Record➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Record","label":"2 - Look Up Record➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Table","label":"2 - Look Up Record➛ATAT:Environment Table","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record","label":"2 - Look Up Record➛ATAT:Environment Record","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record.csp.vendor","label":"2 - Look Up Record➛ATAT:Environment Record➛CSP➛Vendor","reference":"","reference_display":"Vendor","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_cloud_service_provider","column_name":"vendor","choices":[{"label":"Amazon Web Services","image":"","reference":false,"used":false,"rawLabel":"Amazon Web Services","selected":false,"missing":false,"value":"AWS","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Google Cloud Platform","image":"","reference":false,"used":false,"rawLabel":"Google Cloud Platform","selected":false,"missing":false,"value":"GCP","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Microsoft Azure","image":"","reference":false,"used":false,"rawLabel":"Microsoft Azure","selected":false,"missing":false,"value":"AZURE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Oracle Cloud","image":"","reference":false,"used":false,"rawLabel":"Oracle Cloud","selected":false,"missing":false,"value":"ORACLE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}}]},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__dont_treat_as_error__","label":"6➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__action_status__","label":"6➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.table_name","label":"6➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.record","label":"6➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"6ffc5018-4cdb-4ed7-9a5f-3a5d7c8fa9c7.item","label":"5➛ATAT:Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"Created or Updated_1.current.sys_id","label":"Trigger➛Portfolio Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","image":"","reference":false,"used":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","image":"","reference":false,"used":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","image":"","reference":false,"used":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","image":"","reference":false,"used":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","image":"","reference":false,"used":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.message","label":"5➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"eae4ca7a-5ba6-465c-b7bd-6ba1cf184947"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.status","label":"5➛Status","reference_display":"Status","type":"choice","base_type":"choice","attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"828e2127-df28-4eda-af48-ee4e876cca1e"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"uiType":"integer","uiTypeLabel":"Integer","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"edb3c082-a356-4943-a263-55232fc02390"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Table","label":"5➛ATAT:Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Records","label":"5➛ATAT:Operator Records","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.run_start_time","label":"Trigger➛Run Start Time","type":"glide_date_time","base_type":"glide_date_time","attributes":{"test_input_hidden":"true"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__dont_treat_as_error__","label":"4 - Update Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__action_status__","label":"4 - Update Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.table_name","label":"4 - Update Record➛ATAT:Portfolio Table","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.record","label":"4 - Update Record➛ATAT:Portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__dont_treat_as_error__","label":"3 - Log➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__action_status__","label":"3 - Log➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.operators","label":"Trigger➛Portfolio Record➛Pending Operators","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"glide_list","base_type":"glide_list","parent_table_name":"x_g_dis_atat_portfolio","column_name":"operators"},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Count","label":"1➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Table","label":"1➛CLIN Table","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Records","label":"1➛CLIN Records","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"8359b0e6-638d-450a-809c-b2ec5bf3a034.item","label":"2➛Items","reference_display":"Items","type":"document_id","base_type":"document_id","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.record","label":"1➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.table_name","label":"1➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.table_name","label":"2 - Create Record➛ATAT:Provisioning Job Table","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__action_status__","label":"2 - Create Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__dont_treat_as_error__","label":"2 - Create Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{}},{"name":"Created or Updated_1.current.acquisition_package","label":"Trigger➛Portfolio Record➛Acquisition Package","reference":"x_g_dis_atat_acquisition_package","reference_display":"DAPPS:Acquisition Package","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_portfolio","column_name":"acquisition_package"},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.record","label":"5➛Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.table_name","label":"5➛Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"2ade410f-636d-4f9a-b67a-c121b6332e69"}}]</label_cache>
+        <label_cache>[{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛HOTH Job ID","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"2ade410f-636d-4f9a-b67a-c121b6332e69"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.table_name","label":"5➛Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"fbf37007-3218-462d-a3ff-55be4454e848.record","label":"5➛Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"442f160f-062b-422e-aee1-9c563c4045c6.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.acquisition_package","label":"Trigger➛Portfolio Record➛Acquisition Package","reference":"x_g_dis_atat_acquisition_package","reference_display":"DAPPS:Acquisition Package","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_portfolio","column_name":"acquisition_package"},{"name":"Created or Updated_1.current","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__dont_treat_as_error__","label":"2 - Create Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.__action_status__","label":"2 - Create Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.table_name","label":"2 - Create Record➛ATAT:Provisioning Job Table","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record","label":"2 - Create Record➛ATAT:Provisioning Job Record","reference":"x_g_dis_atat_provisioning_job","reference_display":"ATAT:Provisioning Job","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.table_name","label":"1➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"732d228e-3910-4e09-a15f-da16cd49355d.record","label":"1➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"8359b0e6-638d-450a-809c-b2ec5bf3a034.item","label":"2➛Items","reference_display":"Items","type":"document_id","base_type":"document_id","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Records","label":"1➛CLIN Records","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Table","label":"1➛CLIN Table","reference":"x_g_dis_atat_clin","reference_display":"ATAT:CLIN","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.Count","label":"1➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__action_status__","label":"1➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"e2b1d1e1-a3ec-4291-8f8f-3dd745c4789e.__dont_treat_as_error__","label":"1➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.operators","label":"Trigger➛Portfolio Record➛Pending Operators","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"glide_list","base_type":"glide_list","parent_table_name":"x_g_dis_atat_portfolio","column_name":"operators"},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__action_status__","label":"3 - Log➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"454d07c5-33e9-4dd4-9a14-d257befa89a4.__dont_treat_as_error__","label":"3 - Log➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛x_g_dis_atat_portfolio Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.record","label":"4 - Update Record➛ATAT:Portfolio Record","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.table_name","label":"4 - Update Record➛ATAT:Portfolio Table","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__action_status__","label":"4 - Update Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"7ffd664e-d808-4a1b-9be2-e9c4fde0af19.__dont_treat_as_error__","label":"4 - Update Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"Created or Updated_1.run_start_time","label":"Trigger➛Run Start Time","type":"glide_date_time","base_type":"glide_date_time","attributes":{"test_input_hidden":"true"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Records","label":"5➛ATAT:Operator Records","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"records","base_type":"records","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Table","label":"5➛ATAT:Operator Table","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.Count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"bbe6b7dc-037e-4063-a6e6-6270918bd709.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.record","label":"5➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.table_name","label":"5➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"co_type_name":"FDACTIONSTATUS","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"object","action_error_output":"true"}},{"name":"c8fde102-de84-46a1-9010-02fe7a4a6edb.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiType":"boolean","visible_in_ui":"false","action_error_output":"true"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.count","label":"5➛Count","reference_display":"Count","type":"integer","base_type":"integer","attributes":{"uiType":"integer","uiTypeLabel":"Integer","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"edb3c082-a356-4943-a263-55232fc02390"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.status","label":"5➛Status","reference_display":"Status","type":"choice","base_type":"choice","attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"828e2127-df28-4eda-af48-ee4e876cca1e"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.message","label":"5➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"eae4ca7a-5ba6-465c-b7bd-6ba1cf184947"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__action_status__","label":"5➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"24efc1f1-3eea-48d4-9fa0-92d77f369575.__dont_treat_as_error__","label":"5➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"d9e64b95-55b2-4f05-87ec-763b155a845b.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Created or Updated_1.current.sys_id","label":"Trigger➛Portfolio Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"6ffc5018-4cdb-4ed7-9a5f-3a5d7c8fa9c7.item","label":"5➛ATAT:Operator Record","reference":"x_g_dis_atat_operator","reference_display":"ATAT:Operator","type":"reference","base_type":"reference","attributes":{"pills_draggable_inside_block":"true","pills_draggable_outside_block":"false"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.record","label":"6➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.table_name","label":"6➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__action_status__","label":"6➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"081ee68e-1817-43d7-9e03-6951c5111e71.__dont_treat_as_error__","label":"6➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record.csp.vendor","label":"2 - Look Up Record➛ATAT:Environment Record➛CSP➛Vendor","reference":"","reference_display":"Vendor","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_cloud_service_provider","column_name":"vendor","choices":[{"label":"Amazon Web Services","used":false,"image":"","reference":false,"rawLabel":"Amazon Web Services","selected":false,"missing":false,"value":"AWS","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Google Cloud Platform","used":false,"image":"","reference":false,"rawLabel":"Google Cloud Platform","selected":false,"missing":false,"value":"GCP","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Microsoft Azure","used":false,"image":"","reference":false,"rawLabel":"Microsoft Azure","selected":false,"missing":false,"value":"AZURE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}},{"label":"Oracle Cloud","used":false,"image":"","reference":false,"rawLabel":"Oracle Cloud","selected":false,"missing":false,"value":"ORACLE","parameters":{"name":"x_g_dis_atat_cloud_service_provider"}}]},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Record","label":"2 - Look Up Record➛ATAT:Environment Record","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"reference","base_type":"reference","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.Table","label":"2 - Look Up Record➛ATAT:Environment Table","reference":"x_g_dis_atat_environment","reference_display":"ATAT:Environment","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"ca53916a-d4f4-4b8a-9aaa-b83ef17056d6.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Record","label":"2 - Look Up Record➛Record","reference_display":"Record","type":"document_id","base_type":"document_id","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.Table","label":"2 - Look Up Record➛Table","reference_display":"Table","type":"table_name","base_type":"table_name","attributes":{"element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.status","label":"2 - Look Up Record➛Status","reference_display":"Status","type":"choice","base_type":"choice","choices":[{"label":"Error","value":"1","order":0.0},{"label":"Success","value":"0","order":1.0}],"attributes":{"uiType":"choice","uiTypeLabel":"Choice","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"5e478657-3a84-4a60-a92b-d3e80005ad34"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.error_message","label":"2 - Look Up Record➛Error Message","reference_display":"Error Message","type":"string","base_type":"string","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","pwd2droppable":"true","uiUniqueId":"87687532-9e3d-4497-a88e-90f45bfb9adb"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__action_status__","label":"2 - Look Up Record➛Action Status","reference_display":"Action Status","type":"object","base_type":"object","attributes":{"uiType":"object","co_type_name":"FDACTIONSTATUS","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}},{"name":"228e0ed6-9ec1-4a14-9ca1-b690645faf4e.__dont_treat_as_error__","label":"2 - Look Up Record➛Don\u0027t Treat as Error","reference_display":"Don\u0027t Treat as Error","type":"boolean","base_type":"boolean","attributes":{"uiType":"boolean","visible_in_ui":"false","action_error_output":"true","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper"}}]</label_cache>
         <master>true</master>
         <name>PROV: Queue Initial Portfolio Provisioning Job</name>
         <natlang/>
@@ -995,7 +830,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>99d63b37dbb619d0b1227ea5f396190e</sys_id>
-        <sys_mod_count>12</sys_mod_count>
+        <sys_mod_count>18</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
@@ -1003,7 +838,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=99d63b37dbb619d0b1227ea5f396190e"/>
@@ -1018,10 +853,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:34</sys_created_on>
         <sys_id>b1d6bb37dbb619d0b1227ea5f396193f</sys_id>
-        <sys_mod_count>37</sys_mod_count>
+        <sys_mod_count>55</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:11</sys_updated_on>
         <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -1050,9 +885,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:34</sys_created_on>
         <sys_id>7dd6bb37dbb619d0b1227ea5f3961940</sys_id>
-        <sys_mod_count>4</sys_mod_count>
+        <sys_mod_count>6</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:36</sys_updated_on>
+        <sys_updated_on>2023-09-21 19:51:17</sys_updated_on>
         <value>portfolio_ownerISNOTEMPTY^provisioned=false^active_task_orderISNOTEMPTY^active_task_order.clinsISNOTEMPTY^csp_idISEMPTY</value>
         <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
     </sys_variable_value>
@@ -1064,10 +899,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-09-13 18:10:10</sys_created_on>
         <sys_id>e137b0854795bd50f6b8f0bd436d43e1</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-13 18:10:10</sys_updated_on>
-        <value>unique_changes</value>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-21 20:21:48</sys_updated_on>
+        <value>once</value>
         <variable display_value="Run Trigger">2b9def50c31132002841b63b12d3ae5b</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_a45d9180c32222002841b63b12d3aea7^id=b1d6bb37dbb619d0b1227ea5f396193f"/>
@@ -1149,14 +984,14 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:31</sys_created_on>
         <sys_id>d1d63b37dbb619d0b1227ea5f3961913</sys_id>
-        <sys_mod_count>23</sys_mod_count>
+        <sys_mod_count>35</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1315,14 +1150,14 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:32</sys_created_on>
         <sys_id>edd63b37dbb619d0b1227ea5f39619d0</sys_id>
-        <sys_mod_count>23</sys_mod_count>
+        <sys_mod_count>35</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:36</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1337,7 +1172,7 @@
     </sys_hub_flow_input>
     <sys_hub_flow_output action="delete_multiple" query="model=99d63b37dbb619d0b1227ea5f396190e"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=99d63b37dbb619d0b1227ea5f396190e"/>
-    <sys_hub_action_instance action="delete_multiple" query="flow=99d63b37dbb619d0b1227ea5f396190e^sys_idNOT IN29d67b37dbb619d0b1227ea5f39619df,75d6bb37dbb619d0b1227ea5f3961900,79d6bb37dbb619d0b1227ea5f3961907"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=99d63b37dbb619d0b1227ea5f396190e^sys_idNOT IN29d67b37dbb619d0b1227ea5f39619df,75d6bb37dbb619d0b1227ea5f3961900"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
         <action_inputs/>
         <action_inputs/>
@@ -1352,10 +1187,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:33</sys_created_on>
         <sys_id>29d67b37dbb619d0b1227ea5f39619df</sys_id>
-        <sys_mod_count>50</sys_mod_count>
+        <sys_mod_count>74</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <ui_id>d9e64b95-55b2-4f05-87ec-763b155a845b</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=29d67b37dbb619d0b1227ea5f39619df"/>
@@ -1446,9 +1281,9 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:33</sys_created_on>
         <sys_id>e9d67b37dbb619d0b1227ea5f39619e0</sys_id>
-        <sys_mod_count>4</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-09-13 18:07:38</sys_updated_on>
+        <sys_mod_count>7</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
     </sys_hub_input_scripts>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=29d67b37dbb619d0b1227ea5f39619df"/>
     <sys_hub_action_instance action="INSERT_OR_UPDATE">
@@ -1465,10 +1300,10 @@
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2022-11-03 18:22:33</sys_created_on>
         <sys_id>75d6bb37dbb619d0b1227ea5f3961900</sys_id>
-        <sys_mod_count>50</sys_mod_count>
+        <sys_mod_count>74</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <ui_id>454d07c5-33e9-4dd4-9a14-d257befa89a4</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=75d6bb37dbb619d0b1227ea5f3961900"/>
@@ -1499,175 +1334,10 @@
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=75d6bb37dbb619d0b1227ea5f3961900"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=75d6bb37dbb619d0b1227ea5f3961900"/>
-    <sys_hub_action_instance action="INSERT_OR_UPDATE">
-        <action_inputs/>
-        <action_inputs/>
-        <action_type display_value="Update Record">f9d01dd2c31332002841b63b12d3aea1</action_type>
-        <action_type_parent display_value="Update Record">baf174c8c3c232002841b63b12d3aee4</action_type_parent>
-        <comment>set status to Processing and record provisioning request date</comment>
-        <display_text/>
-        <flow display_value="PROV: Queue Initial Portfolio Provisioning Job">99d63b37dbb619d0b1227ea5f396190e</flow>
-        <order>4</order>
-        <parent_ui_id/>
-        <sys_class_name>sys_hub_action_instance</sys_class_name>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2022-11-03 18:22:33</sys_created_on>
-        <sys_id>79d6bb37dbb619d0b1227ea5f3961907</sys_id>
-        <sys_mod_count>50</sys_mod_count>
-        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
-        <ui_id>7ffd664e-d808-4a1b-9be2-e9c4fde0af19</ui_id>
-    </sys_hub_action_instance>
-    <sys_variable_value action="delete_multiple" query="document_key=79d6bb37dbb619d0b1227ea5f3961907"/>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>79d6bb37dbb619d0b1227ea5f3961907</document_key>
-        <order>50</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:39</sys_created_on>
-        <sys_id>7a4867a947d52110f39f7601e36d4346</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:39</sys_updated_on>
-        <value>x_g_dis_atat_portfolio</value>
-        <variable display_value="Table">1fd27c8cc3c632002841b63b12d3aeb9</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>79d6bb37dbb619d0b1227ea5f3961907</document_key>
-        <order>100</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2023-03-14 21:28:15</sys_created_on>
-        <sys_id>839907cedbe92d148c045e8cd39619ca</sys_id>
-        <sys_mod_count>2</sys_mod_count>
-        <sys_updated_by>eric.youngquist</sys_updated_by>
-        <sys_updated_on>2023-07-12 15:30:42</sys_updated_on>
-        <value>portfolio_status=PROCESSING^provisioning_request_date=fd-scripted^portfolio_owner=fd-scripted^=</value>
-        <variable display_value="Fields">02d01916c31332002841b63b12d3aeee</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>79d6bb37dbb619d0b1227ea5f3961907</document_key>
-        <order>50</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2022-11-03 18:22:34</sys_created_on>
-        <sys_id>b5d6bb37dbb619d0b1227ea5f3961909</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2022-11-03 18:22:34</sys_updated_on>
-        <value>x_g_dis_atat_portfolio</value>
-        <variable display_value="Table">b5d01916c31332002841b63b12d3aec9</variable>
-    </sys_variable_value>
-    <sys_variable_value action="INSERT_OR_UPDATE">
-        <document>sys_hub_action_instance</document>
-        <document_key>79d6bb37dbb619d0b1227ea5f3961907</document_key>
-        <order>100</order>
-        <sys_class_name>sys_variable_value</sys_class_name>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:39</sys_created_on>
-        <sys_id>b64867a947d52110f39f7601e36d4346</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:39</sys_updated_on>
-        <value>portfolio_status=PROCESSING</value>
-        <variable display_value="Fields">e7d270ccc3c632002841b63b12d3ae8b</variable>
-    </sys_variable_value>
-    <sys_element_mapping action="delete_multiple" query="id=79d6bb37dbb619d0b1227ea5f3961907"/>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>record</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:39</sys_created_on>
-        <sys_id>724867a947d52110f39f7601e36d4346</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:39</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value>{{Created or Updated_1.current}}</value>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>record</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2022-11-03 18:22:34</sys_created_on>
-        <sys_id>71d6bb37dbb619d0b1227ea5f3961909</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2022-11-03 18:22:34</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value>{{Created or Updated_1.current}}</value>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>table_name</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:39</sys_created_on>
-        <sys_id>be4867a947d52110f39f7601e36d4345</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:39</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>table_name</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2022-11-03 18:22:34</sys_created_on>
-        <sys_id>bdd6bb37dbb619d0b1227ea5f3961908</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2022-11-03 18:22:34</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>values</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
-        <sys_created_on>2023-03-01 00:09:39</sys_created_on>
-        <sys_id>364867a947d52110f39f7601e36d4346</sys_id>
-        <sys_mod_count>0</sys_mod_count>
-        <sys_updated_by>julius.fitzhugh-ctr</sys_updated_by>
-        <sys_updated_on>2023-03-01 00:09:39</sys_updated_on>
-        <table>var__m_sys_hub_action_input_baf174c8c3c232002841b63b12d3aee4</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_element_mapping action="INSERT_OR_UPDATE">
-        <field>values</field>
-        <id>79d6bb37dbb619d0b1227ea5f3961907</id>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2022-11-03 18:22:34</sys_created_on>
-        <sys_id>35d6bb37dbb619d0b1227ea5f3961909</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-03-14 21:28:15</sys_updated_on>
-        <table>var__m_sys_hub_action_input_f9d01dd2c31332002841b63b12d3aea1</table>
-        <value/>
-    </sys_element_mapping>
-    <sys_hub_input_scripts action="delete_multiple" query="instance=79d6bb37dbb619d0b1227ea5f3961907^sys_idNOT INc3a756fadbe161548c045e8cd39619e9"/>
-    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
-        <active>true</active>
-        <input_name>values</input_name>
-        <instance>79d6bb37dbb619d0b1227ea5f3961907</instance>
-        <referenced_table>sys_hub_action_instance</referenced_table>
-        <script>{"provisioning_request_date":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**Available options display upon pressing \".\" after fd_data\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nreturn new GlideDateTime().getDisplayValue();","savedValue":""},"portfolio_owner":{"scriptActive":true,"script":"/*\n**Access Flow/Action data using the fd_data object. Script must return a value.\n**Available options display upon pressing \".\" after fd_data\n**example: var shortDesc \u003d fd_data.trigger.current.short_description;\n**return shortDesc;\n*/\nconst createdByUserId \u003d fd_data.trigger.current.sys_created_by;\ngs.info(\"IN FLOW: createdByUserId: \" + createdByUserId)\nconst userGr \u003d new GlideRecord(\u0027sys_user\u0027);\nuserGr.addQuery(\u0027user_name\u0027, createdByUserId);\nuserGr.query();\nif (userGr.next()) {\n    gs.info(\"IN FLOW: user sys_id: \" + userGr.sys_id);\n    return userGr.sys_id;\n} else {\n    throw new Error(`User with ID ${createdByUserId} not found.`);\n}\n","savedValue":""}}</script>
-        <sys_created_by>1370228783.CTR</sys_created_by>
-        <sys_created_on>2023-03-17 01:45:31</sys_created_on>
-        <sys_id>c3a756fadbe161548c045e8cd39619e9</sys_id>
-        <sys_mod_count>3</sys_mod_count>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-08-02 21:03:31</sys_updated_on>
-    </sys_hub_input_scripts>
-    <sys_hub_alias_mapping action="delete_multiple" query="source_id=79d6bb37dbb619d0b1227ea5f3961907"/>
     <sys_hub_sub_flow_instance action="delete_multiple" query="flow=99d63b37dbb619d0b1227ea5f396190e"/>
     <sys_hub_flow_logic action="delete_multiple" query="flow=99d63b37dbb619d0b1227ea5f396190e^sys_idNOT IN364867a947d52110f39f7601e36d4347"/>
     <sys_hub_flow_logic action="INSERT_OR_UPDATE">
-        <block display_value="">6f306c559715f1105e3a797e6253af0e</block>
+        <block display_value="">806424179791311084aaf8a6f053af50</block>
         <comment/>
         <connected_to/>
         <decision_table/>
@@ -1687,10 +1357,10 @@
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2023-03-01 00:09:39</sys_created_on>
         <sys_id>364867a947d52110f39f7601e36d4347</sys_id>
-        <sys_mod_count>32</sys_mod_count>
+        <sys_mod_count>45</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-14 11:08:37</sys_updated_on>
+        <sys_updated_on>2023-09-21 20:25:10</sys_updated_on>
         <ui_id>7bf04fd6-96cc-4cfc-8f4e-fb2d9c1c75ac</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -1873,6 +1543,6 @@
     <sys_hub_flow action="UPDATE">
         <sys_id>a0ff1bf42fd15110e58359a72799b63b</sys_id>
         <latest_snapshot>99d63b37dbb619d0b1227ea5f396190e</latest_snapshot>
-        <compiler_build>glide-tokyo-07-08-2022__patch9-hotfix2b-07-19-2023_08-01-2023_1829.zip</compiler_build>
+        <compiler_build>glide-tokyo-07-08-2022__patch9-hotfix2-06-07-2023_06-23-2023_1740.zip</compiler_build>
     </sys_hub_flow>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_abc17e0edba4e918b1227ea5f39619fc.xml
@@ -270,7 +270,8 @@ Eda.prototype = {
         portfolio.setValue("name", portfolioName);
         portfolio.setValue("portfolio_owner", gs.getUserID());
         portfolio.setValue("agency", portfolioAgency);
-
+		const todaysDate = new GlideDateTime().getDisplayValue();
+		portfolio.setValue("provisioning_request_date", todaysDate);
         // set CSP column with first (?) environment name from POST body
         const cspName = environments?.[0]?.cspName;
 
@@ -654,13 +655,13 @@ Eda.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-01-24 02:42:04</sys_created_on>
         <sys_id>abc17e0edba4e918b1227ea5f39619fc</sys_id>
-        <sys_mod_count>110</sys_mod_count>
+        <sys_mod_count>111</sys_mod_count>
         <sys_name>Eda</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_abc17e0edba4e918b1227ea5f39619fc</sys_update_name>
-        <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-09-13 22:31:20</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-21 19:59:23</sys_updated_on>
     </sys_script_include>
 </record_update>


### PR DESCRIPTION
Removing flow step from PROV: Queue Initial , updating eda script to set prov start date.

Removed `updated ATAT: portfolio record` step from from PROV: Queue Initial Portfolio Provisioning Job:
![image](https://github.com/dod-ccpo/atat-snow/assets/139161354/55cb7648-9f06-4505-86fe-3794b3413095)


Added in provisioning date into EDA script include:
![image](https://github.com/dod-ccpo/atat-snow/assets/139161354/6c4bba55-3dfc-4b6b-82fa-7bb52d4a535c)


