### PR TITLE
Feature/at 9552 create api for dashboard portfolios

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
@@ -94,7 +94,7 @@ GetUserPortfolios.prototype = {
 				total_obligated: clinDetails.fundsObligated,
 				funds_spent: clinDetails.fundsSpent,
 				active_task_order: gr.active_task_order.getDisplayValue().toString(),
-				owner_full_name: gr.portfolio_owner.getDisplayValue().toString(), //sys_user.name
+				owner_full_name: gr.portfolio_owner.getDisplayValue().toString(),
 				funding_status: gr.portfolio_funding_status.toString(),
 				csp_portal_links: this.getCSPLinks(gr.sys_id)
 			};
@@ -110,13 +110,13 @@ GetUserPortfolios.prototype = {
         <sys_created_by>tom.arnold</sys_created_by>
         <sys_created_on>2023-09-23 02:03:45</sys_created_on>
         <sys_id>cdc93cc84761311039634aff336d4316</sys_id>
-        <sys_mod_count>57</sys_mod_count>
+        <sys_mod_count>58</sys_mod_count>
         <sys_name>GetUserPortfolios</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_cdc93cc84761311039634aff336d4316</sys_update_name>
         <sys_updated_by>tom.arnold</sys_updated_by>
-        <sys_updated_on>2023-09-24 20:56:15</sys_updated_on>
+        <sys_updated_on>2023-09-24 21:04:38</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
@@ -85,7 +85,7 @@ GetUserPortfolios.prototype = {
 				portfolio_name: gr.name.toString(),
 				portfolio_status: gr.portfolio_status.toString(),
 				agency: this.getAgency(gr.agency),
-				last_modified: gr.last_updated,
+				last_updated: gr.last_updated,
 				current_user_is_owner: gr.portfolio_owner.toString() === this.userId ? true : false, 
 				current_user_is_manager: JSON.stringify(gr.portfolio_managers.toString()).includes(this.userId) ? true: false,
 				vendor: this.getVendor(gr.csp),
@@ -110,13 +110,13 @@ GetUserPortfolios.prototype = {
         <sys_created_by>tom.arnold</sys_created_by>
         <sys_created_on>2023-09-23 02:03:45</sys_created_on>
         <sys_id>cdc93cc84761311039634aff336d4316</sys_id>
-        <sys_mod_count>58</sys_mod_count>
+        <sys_mod_count>59</sys_mod_count>
         <sys_name>GetUserPortfolios</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_cdc93cc84761311039634aff336d4316</sys_update_name>
         <sys_updated_by>tom.arnold</sys_updated_by>
-        <sys_updated_on>2023-09-24 21:04:38</sys_updated_on>
+        <sys_updated_on>2023-09-24 21:06:03</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_script_include">
+    <sys_script_include action="INSERT_OR_UPDATE">
+        <access>package_private</access>
+        <active>true</active>
+        <api_name>x_g_dis_atat.GetUserPortfolios</api_name>
+        <caller_access/>
+        <client_callable>false</client_callable>
+        <description/>
+        <name>GetUserPortfolios</name>
+        <script><![CDATA[let GetUserPortfolios = Class.create();
+
+GetUserPortfolios.prototype = {
+    userId: null,
+    errUtil: new ErrorHandler(),
+    PORTFOLIO_TABLE: 'x_g_dis_atat_portfolio',
+	AGENCY_TABLE: 'x_g_dis_atat_agency',
+	TASK_ORDER_TABLE: 'x_g_dis_atat_task_order',
+	CLIN_TABLE: 'x_g_dis_atat_clin',
+	VENDOR_TABLE: 'x_g_dis_atat_cloud_service_provider',
+	ENVIRONMENT_TABLE: 'x_g_dis_atat_environment',
+	
+    initialize: function(userSysId) {
+        this.userId = userSysId;
+    },
+	getVendor: function(id){
+		let gr = new GlideRecord(this.VENDOR_TABLE);
+		gr.get(id);
+		return gr.vendor.toString();
+	},
+	getAgency: function(id) {
+		let gr = new GlideRecord(this.AGENCY_TABLE);
+		gr.get(id);
+		return gr.title.toString();
+	},
+	getTODetails: function(toId){
+		let gr = new GlideRecord(this.TASK_ORDER_TABLE);
+		gr.get(toId);
+		return {
+			popStart: gr.pop_start_date,
+			popEnd: gr.pop_end_date
+		};
+	},
+	getCLINData: function(toId){
+		let gr = new GlideRecord(this.CLIN_TABLE);
+		let fundsObligated = 0.00;
+		let fundsSpent = 0.00;
+		gr.addQuery('task_order',toId).addCondition("clin_status", "!=", "OPTION_PENDING").addCondition("clin_status","!=","EXPIRED");
+		gr.query();
+		while(gr.next()){
+			fundsObligated += parseFloat(gr.funds_obligated);
+			fundsSpent += parseFloat(gr.actual_funds_spent);
+		}
+		return {
+			fundsObligated: fundsObligated,
+			fundsSpent: fundsSpent
+		};
+	},
+	getCSPLinks: function(id){
+		let environments = [];
+		let gr = new GlideRecord(this.ENVIRONMENT_TABLE);
+		gr.addQuery('portfolio', id);
+		gr.query();
+		while(gr.next()){
+			let csp = gr.csp.getDisplayValue().toString();
+			let dashboardLink = gr.dashboard_link.toString();
+			let data = {
+				csp: csp,
+				dashboard_link: dashboardLink
+			};
+			environments.push(data);
+		}
+		return environments;
+	},
+	getPortfolioDetails: function() {
+		let data = [];
+        let gr = new GlideRecord(this.PORTFOLIO_TABLE);
+		gr.addQuery('portfolio_owner',this.userId)
+			.addOrCondition('portfolio_managers','CONTAINS',this.userId)
+			.addOrCondition('portfolio_viewers','CONTAINS',this.userId);
+        gr.query();
+        while(gr.next()){
+			let toDetails = this.getTODetails(gr.active_task_order.sys_id);
+			let clinDetails = this.getCLINData(gr.active_task_order.sys_id);
+			let portfolio = {
+				portfolio_name: gr.name.toString(),
+				portfolio_status: gr.portfolio_status.toString(),
+				agency: this.getAgency(gr.agency),
+				last_modified: gr.last_updated,
+				current_user_is_owner: gr.portfolio_owner.toString() === this.userId ? true : false, 
+				current_user_is_manager: JSON.stringify(gr.portfolio_managers.toString()).includes(this.userId) ? true: false,
+				vendor: this.getVendor(gr.csp),
+				pop_start_date: toDetails.popStart,
+				pop_end_date: toDetails.popEnd,
+				total_obligated: clinDetails.fundsObligated,
+				funds_spent: clinDetails.fundsSpent,
+				active_task_order: gr.active_task_order.getDisplayValue().toString(),
+				owner_full_name: gr.portfolio_owner.getDisplayValue().toString(), //sys_user.name
+				funding_status: gr.portfolio_funding_status.toString(),
+				csp_portal_links: this.getCSPLinks(gr.sys_id)
+			};
+            data.push(portfolio);
+        }
+
+        return data;
+	},
+
+    type: 'GetUserPortfolios'
+};]]></script>
+        <sys_class_name>sys_script_include</sys_class_name>
+        <sys_created_by>tom.arnold</sys_created_by>
+        <sys_created_on>2023-09-23 02:03:45</sys_created_on>
+        <sys_id>cdc93cc84761311039634aff336d4316</sys_id>
+        <sys_mod_count>57</sys_mod_count>
+        <sys_name>GetUserPortfolios</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy>read</sys_policy>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_script_include_cdc93cc84761311039634aff336d4316</sys_update_name>
+        <sys_updated_by>tom.arnold</sys_updated_by>
+        <sys_updated_on>2023-09-24 20:56:15</sys_updated_on>
+    </sys_script_include>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
@@ -41,15 +41,20 @@ GetUserPortfolios.prototype = {
 		};
 	},
 	getCLINData: function(toId){
-		let gr = new GlideRecord(this.CLIN_TABLE);
 		let fundsObligated = 0.00;
 		let fundsSpent = 0.00;
-		gr.addQuery('task_order',toId).addCondition("clin_status", "!=", "OPTION_PENDING").addCondition("clin_status","!=","EXPIRED");
-		gr.query();
-		while(gr.next()){
-			fundsObligated += parseFloat(gr.funds_obligated);
-			fundsSpent += parseFloat(gr.actual_funds_spent);
-		}
+		let list = new global.GlideQuery(this.CLIN_TABLE)
+		.where('task_order',toId.toString())
+		.select('funds_obligated','actual_funds_spent','clin_status')
+		.toArray(100);
+		
+		list.forEach(function(clin) {
+			if(clin.clin_status != 'OPTION_PENDING' || clin.clin_status != 'EXPIRED'){
+				fundsObligated += parseFloat(clin.funds_obligated);
+				fundsSpent += parseFloat(clin.actual_funds_spent);
+			}
+			
+		});
 		return {
 			fundsObligated: fundsObligated,
 			fundsSpent: fundsSpent
@@ -110,13 +115,13 @@ GetUserPortfolios.prototype = {
         <sys_created_by>tom.arnold</sys_created_by>
         <sys_created_on>2023-09-23 02:03:45</sys_created_on>
         <sys_id>cdc93cc84761311039634aff336d4316</sys_id>
-        <sys_mod_count>59</sys_mod_count>
+        <sys_mod_count>68</sys_mod_count>
         <sys_name>GetUserPortfolios</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_cdc93cc84761311039634aff336d4316</sys_update_name>
         <sys_updated_by>tom.arnold</sys_updated_by>
-        <sys_updated_on>2023-09-24 21:06:03</sys_updated_on>
+        <sys_updated_on>2023-09-25 23:50:00</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_definition_5256ec484721311039634aff336d43e8.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_definition_5256ec484721311039634aff336d43e8.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_definition">
+    <sys_ws_definition action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <base_uri>/api/x_g_dis_atat/portfolios</base_uri>
+        <consumes>application/json,application/xml,text/xml</consumes>
+        <consumes_customized>false</consumes_customized>
+        <default_version>No active default version</default_version>
+        <doc_link/>
+        <enforce_acl>cf9d01d3e73003009d6247e603f6a990</enforce_acl>
+        <is_versioned>false</is_versioned>
+        <name>Portfolios</name>
+        <namespace>x_g_dis_atat</namespace>
+        <produces>application/json,application/xml,text/xml</produces>
+        <produces_customized>false</produces_customized>
+        <service_id>portfolios</service_id>
+        <short_description/>
+        <sys_class_name>sys_ws_definition</sys_class_name>
+        <sys_created_by>tom.arnold</sys_created_by>
+        <sys_created_on>2023-09-23 00:39:09</sys_created_on>
+        <sys_id>5256ec484721311039634aff336d43e8</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Portfolios</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_definition_5256ec484721311039634aff336d43e8</sys_update_name>
+        <sys_updated_by>tom.arnold</sys_updated_by>
+        <sys_updated_on>2023-09-23 00:39:09</sys_updated_on>
+    </sys_ws_definition>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_d5b5820447a5311039634aff336d4308.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_d5b5820447a5311039634aff336d4308.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_operation">
+    <sys_ws_operation action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <consumes>application/json,application/xml,text/xml</consumes>
+        <consumes_customized>false</consumes_customized>
+        <default_operation_uri/>
+        <enforce_acl>cf9d01d3e73003009d6247e603f6a990</enforce_acl>
+        <http_method>GET</http_method>
+        <name>Summary</name>
+        <operation_script><![CDATA[(function process(/*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
+  try{
+    if(!request.queryParams.userId) {
+        response.setStatus(400);
+        response.setBody({
+            "userId": request.queryParams.userId,
+            "error_message": "query parameter userId is required"
+        });
+    } else if (request.queryParams.userId.toString().length != 32) {
+        response.setStatus(400);
+        response.setBody({
+            "userId": request.queryParams.userId.toString(),
+            "error_message": "query parameter userId must be a 32 char sys_id"
+        });
+    } else {
+        let userId = request.queryParams.userId.toString();
+        let PORTFOLIO_TABLE = "x_g_dis_atat_portfolio";
+		const port = new GetUserPortfolios(userId);
+		let portfolios = port.getPortfolioDetails();
+		response.setStatus(200);
+		response.setContentType('application/json');
+		response.setBody({
+			"Portfolios": portfolios,
+			"userId": userId
+		});
+    } 
+  } catch (err) {
+        response.setStatus(400);
+        response.setBody(err);
+        let errUtil = new ErrorHandler();
+       throw errUtil.createError(
+            "Portfolio REST API --> Get PortfoliosSummaryList: " + err,
+           errUtil.METHOD_ERROR
+        );
+    }
+})(request, response);]]></operation_script>
+        <operation_uri>/api/x_g_dis_atat/portfolios/summary</operation_uri>
+        <produces>application/json,application/xml,text/xml</produces>
+        <produces_customized>false</produces_customized>
+        <relative_path>/summary</relative_path>
+        <request_example/>
+        <requires_acl_authorization>true</requires_acl_authorization>
+        <requires_authentication>true</requires_authentication>
+        <requires_snc_internal_role>true</requires_snc_internal_role>
+        <short_description/>
+        <sys_class_name>sys_ws_operation</sys_class_name>
+        <sys_created_by>tom.arnold</sys_created_by>
+        <sys_created_on>2023-09-23 07:37:02</sys_created_on>
+        <sys_id>d5b5820447a5311039634aff336d4308</sys_id>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_name>Summary</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_operation_d5b5820447a5311039634aff336d4308</sys_update_name>
+        <sys_updated_by>tom.arnold</sys_updated_by>
+        <sys_updated_on>2023-09-24 20:59:22</sys_updated_on>
+        <web_service_definition display_value="Portfolios">5256ec484721311039634aff336d43e8</web_service_definition>
+        <web_service_version/>
+    </sys_ws_operation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_68fc64804761311039634aff336d43b4.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_68fc64804761311039634aff336d43b4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter">
+    <sys_ws_query_parameter action="INSERT_OR_UPDATE">
+        <example_value/>
+        <name>userId</name>
+        <required>false</required>
+        <short_description/>
+        <sys_class_name>sys_ws_query_parameter</sys_class_name>
+        <sys_created_by>tom.arnold</sys_created_by>
+        <sys_created_on>2023-09-23 01:07:30</sys_created_on>
+        <sys_id>68fc64804761311039634aff336d43b4</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>userId</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_68fc64804761311039634aff336d43b4</sys_update_name>
+        <sys_updated_by>tom.arnold</sys_updated_by>
+        <sys_updated_on>2023-09-23 01:07:30</sys_updated_on>
+        <web_service_definition display_value="Portfolios">5256ec484721311039634aff336d43e8</web_service_definition>
+    </sys_ws_query_parameter>
+</record_update>


### PR DESCRIPTION
Created new Scripted REST API `Portfolios`  with a Scripted REST Resource `summary` that will return an array of JSON objects needed to fill out the dashboard and Portfolio list screens. 
`summary` can return the following status codes:
* 400
* 200

400:
Will return if a `userId` is not passed as a query parameter with the request, or if the `userId` is not 32 characters in length.  This is expecting a `sysId` for a user.

200:
Will call the Script Include `GetUserPortfolios` to do the heavy lifting of identifying which portfolio's the provided `userId` has access to, and then return the necessary fields to populate the dashboard and the portfolio list screens. 
![image](https://github.com/dod-ccpo/atat-snow/assets/77513554/82a81361-e0ad-4abb-af5f-98fae0dd9758)
