### PR TITLE
AT-9482: Implemented /user_proxy/self/roles operation

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_scope_privilege_9178ce7c97613110c4cffaafe153afa7.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_scope_privilege_9178ce7c97613110c4cffaafe153afa7.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_scope_privilege">
+    <sys_scope_privilege action="INSERT_OR_UPDATE">
+        <operation>read</operation>
+        <source_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</source_scope>
+        <status>allowed</status>
+        <sys_class_name>sys_scope_privilege</sys_class_name>
+        <sys_created_by>jeffsegal</sys_created_by>
+        <sys_created_on>2023-09-25 15:42:21</sys_created_on>
+        <sys_id>9178ce7c97613110c4cffaafe153afa7</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>sys_user_has_role</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_scope_privilege_9178ce7c97613110c4cffaafe153afa7</sys_update_name>
+        <sys_updated_by>jeffsegal</sys_updated_by>
+        <sys_updated_on>2023-09-25 15:42:21</sys_updated_on>
+        <target_name>sys_user_has_role</target_name>
+        <target_scope display_value="Global">global</target_scope>
+        <target_type>sys_db_object</target_type>
+    </sys_scope_privilege>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_4720fdf497213110c4cffaafe153af52.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_4720fdf497213110c4cffaafe153af52.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_operation">
+    <sys_ws_operation action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <consumes>application/json,application/xml,text/xml</consumes>
+        <consumes_customized>false</consumes_customized>
+        <default_operation_uri/>
+        <enforce_acl>cf9d01d3e73003009d6247e603f6a990</enforce_acl>
+        <http_method>GET</http_method>
+        <name>Get My Roles</name>
+        <operation_script><![CDATA[(function process(/*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
+	const filter = request.queryParams.filter;
+	const roles = [];
+	const userRole = new GlideRecord("sys_user_has_role");
+	userRole.addQuery("user", gs.getUserID());
+	userRole.query();
+	while (userRole.next()) {
+		roles.push(userRole.role.getDisplayValue());
+	}
+	if (!filter) {
+		return roles;
+	}
+	else {
+		const filterRoles = filter.toString().split(",");
+		const filtered = roles.filter(function (role) {
+			return filterRoles.includes(role);
+		});
+		response.setStatus(filterRoles.length !== filtered.length ? 404 : 200);
+		return filtered;
+	}
+})(request, response);]]></operation_script>
+        <operation_uri>/api/x_g_dis_atat/user_proxy/self/roles</operation_uri>
+        <produces>application/json,application/xml,text/xml</produces>
+        <produces_customized>false</produces_customized>
+        <relative_path>/self/roles</relative_path>
+        <request_example/>
+        <requires_acl_authorization>true</requires_acl_authorization>
+        <requires_authentication>true</requires_authentication>
+        <requires_snc_internal_role>true</requires_snc_internal_role>
+        <short_description/>
+        <sys_class_name>sys_ws_operation</sys_class_name>
+        <sys_created_by>jeffsegal</sys_created_by>
+        <sys_created_on>2023-09-25 13:56:32</sys_created_on>
+        <sys_id>4720fdf497213110c4cffaafe153af52</sys_id>
+        <sys_mod_count>5</sys_mod_count>
+        <sys_name>Get My Roles</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_operation_4720fdf497213110c4cffaafe153af52</sys_update_name>
+        <sys_updated_by>jeffsegal</sys_updated_by>
+        <sys_updated_on>2023-09-25 15:44:26</sys_updated_on>
+        <web_service_definition display_value="User Proxy">2112e0f6dbb269508c045e8cd3961948</web_service_definition>
+        <web_service_version/>
+    </sys_ws_operation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_41f74a7c97613110c4cffaafe153afe6.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_41f74a7c97613110c4cffaafe153afe6.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter">
+    <sys_ws_query_parameter action="INSERT_OR_UPDATE">
+        <example_value>snc_internal,snc_external</example_value>
+        <name>filter</name>
+        <required>false</required>
+        <short_description>Comma-delimitted list of roles to query</short_description>
+        <sys_class_name>sys_ws_query_parameter</sys_class_name>
+        <sys_created_by>jeffsegal</sys_created_by>
+        <sys_created_on>2023-09-25 15:40:47</sys_created_on>
+        <sys_id>41f74a7c97613110c4cffaafe153afe6</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>filter</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_41f74a7c97613110c4cffaafe153afe6</sys_update_name>
+        <sys_updated_by>jeffsegal</sys_updated_by>
+        <sys_updated_on>2023-09-25 15:40:47</sys_updated_on>
+        <web_service_definition display_value="User Proxy">2112e0f6dbb269508c045e8cd3961948</web_service_definition>
+    </sys_ws_query_parameter>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_ed288e7c97613110c4cffaafe153afad.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_ed288e7c97613110c4cffaafe153afad.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter_map">
+    <sys_ws_query_parameter_map action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_ws_query_parameter_map</sys_class_name>
+        <sys_created_by>jeffsegal</sys_created_by>
+        <sys_created_on>2023-09-25 15:41:09</sys_created_on>
+        <sys_id>ed288e7c97613110c4cffaafe153afad</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>41f74a7c97613110c4cffaafe153afe6</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_map_ed288e7c97613110c4cffaafe153afad</sys_update_name>
+        <sys_updated_by>jeffsegal</sys_updated_by>
+        <sys_updated_on>2023-09-25 15:41:09</sys_updated_on>
+        <web_service_operation display_value="Get My Roles">4720fdf497213110c4cffaafe153af52</web_service_operation>
+        <web_service_query_parameter display_value="filter">41f74a7c97613110c4cffaafe153afe6</web_service_query_parameter>
+    </sys_ws_query_parameter_map>
+</record_update>


### PR DESCRIPTION
This operation will allow the UI to easily query to determine if the current user has a given role. Includes a `filter` parameter in case we are concerned about a large number of roles coming back in the response.

```js
(function process(/*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
	const filter = request.queryParams.filter;
	const roles = [];
	const userRole = new GlideRecord("sys_user_has_role");
	userRole.addQuery("user", gs.getUserID());
	userRole.query();
	while (userRole.next()) {
		roles.push(userRole.role.getDisplayValue());
	}
	if (!filter) {
		return roles;
	}
	else {
		const filterRoles = filter.toString().split(",");
		const filtered = roles.filter(function (role) {
			return filterRoles.includes(role);
		});
		response.setStatus(filterRoles.length !== filtered.length ? 404 : 200);
		return filtered;
	}
})(request, **response);**
```