### PR TITLE
AT-9531: Create PROV: Get Portfolio Flow

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_6b5cbb419725311000989fa00153af80.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_action_type_definition_6b5cbb419725311000989fa00153af80.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update sys_domain="global" table="sys_hub_action_type_definition">
+    <sys_hub_action_type_definition action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <acls/>
+        <action_status/>
+        <action_template/>
+        <active>true</active>
+        <annotation/>
+        <callable_by_client_api>false</callable_by_client_api>
+        <category/>
+        <compiler_build/>
+        <copied_from/>
+        <copied_from_name/>
+        <description/>
+        <ih_action>false</ih_action>
+        <internal_name>prov_get_portfolio</internal_name>
+        <label_cache/>
+        <latest_snapshot/>
+        <master_snapshot/>
+        <name>PROV: Get Portfolio</name>
+        <natlang/>
+        <outputs/>
+        <pre_compiled>false</pre_compiled>
+        <state>draft</state>
+        <sys_class_name>sys_hub_action_type_definition</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:47:15</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>6b5cbb419725311000989fa00153af80</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>PROV: Get Portfolio</sys_name>
+        <sys_overrides/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_action_type_definition_6b5cbb419725311000989fa00153af80</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:47:15</sys_updated_on>
+        <system_level>false</system_level>
+        <type/>
+    </sys_hub_action_type_definition>
+    <sys_translated_text action="delete_multiple" query="documentkey=6b5cbb419725311000989fa00153af80"/>
+    <sys_variable_value action="delete_multiple" query="document_key=6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_step_instance action="delete_multiple" query="action=6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_action_input action="delete_multiple" query="model=6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_action_output action="delete_multiple" query="model=6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_pill_compound action="delete_multiple" query="attached_to=6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_action_status_metadata action="delete_multiple" query="action_type_id=6b5cbb419725311000989fa00153af80"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_action_input_6b5cbb419725311000989fa00153af80"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_action_input_6b5cbb419725311000989fa00153af80"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_action_output_6b5cbb419725311000989fa00153af80"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_action_output_6b5cbb419725311000989fa00153af80"/>
+    <sys_hub_action_plan action="delete_multiple" query="action_id=6b5cbb419725311000989fa00153af80"/>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_4f42734997a1311000989fa00153afd0.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_4f42734997a1311000989fa00153afd0.xml
@@ -10,13 +10,13 @@
         <copied_from_name/>
         <description>Flow to retrieve CSP data pertaining to Portfolios, Task Orders, and Environments.</description>
         <internal_name>prov_get_portfolio</internal_name>
-        <label_cache>[{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}}]</label_cache>
+        <label_cache>[{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_environment","column_name":"name"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"}]</label_cache>
         <master_snapshot>20e7c42197e1711000989fa00153af24</master_snapshot>
         <name>PROV: Get Portfolio</name>
         <natlang/>
         <outputs/>
         <pre_compiled>false</pre_compiled>
-        <remote_trigger_id>81e7c42197e1711000989fa00153afc5</remote_trigger_id>
+        <remote_trigger_id>913ec0e597e1711000989fa00153af05</remote_trigger_id>
         <run_as>system</run_as>
         <run_with_roles/>
         <sc_callable>false</sc_callable>
@@ -29,7 +29,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>4f42734997a1311000989fa00153afd0</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>12</sys_mod_count>
         <sys_name>PROV: Get Portfolio</sys_name>
         <sys_overrides/>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
@@ -37,15 +37,15 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_hub_flow_4f42734997a1311000989fa00153afd0</sys_update_name>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow>
     <sys_translated_text action="delete_multiple" query="documentkey=4f42734997a1311000989fa00153afd0"/>
     <sys_variable_value action="delete_multiple" query="document_key=4f42734997a1311000989fa00153afd0"/>
     <sys_flow_record_trigger action="INSERT_OR_UPDATE">
         <active>true</active>
-        <condition table="x_g_dis_atat_environment">csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING<item endquery="false" field="csp_id" goto="false" newquery="false" operator="EMPTYSTRING" or="false" value=""/>
-            <item endquery="false" field="dashboard_link" goto="false" newquery="true" operator="EMPTYSTRING" or="false" value=""/>
+        <condition table="x_g_dis_atat_environment">csp_idISEMPTY^NQdashboard_linkISEMPTY<item endquery="false" field="csp_id" goto="false" newquery="false" operator="ISEMPTY" or="false" value=""/>
+            <item endquery="false" field="dashboard_link" goto="false" newquery="true" operator="ISEMPTY" or="false" value=""/>
         </condition>
         <name/>
         <on_delete>false</on_delete>
@@ -58,15 +58,15 @@
         <run_when_user_setting>any</run_when_user_setting>
         <sys_class_name>sys_flow_record_trigger</sys_class_name>
         <sys_created_by>admin</sys_created_by>
-        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_created_on>2023-09-27 14:43:40</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
-        <sys_id>81e7c42197e1711000989fa00153afc5</sys_id>
+        <sys_id>913ec0e597e1711000989fa00153af05</sys_id>
         <sys_mod_count>0</sys_mod_count>
         <sys_overrides/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <table>x_g_dis_atat_environment</table>
     </sys_flow_record_trigger>
     <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
@@ -75,14 +75,14 @@
         <identifier>4f42734997a1311000989fa00153afd0</identifier>
         <runner>FDTriggerRunner</runner>
         <sys_created_by>admin</sys_created_by>
-        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
-        <sys_id>0de7c42197e1711000989fa00153afc5</sys_id>
+        <sys_created_on>2023-09-27 14:43:40</sys_created_on>
+        <sys_id>1d3ec0e597e1711000989fa00153af05</sys_id>
         <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
-        <trigger display_value="">81e7c42197e1711000989fa00153afc5</trigger>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
+        <trigger display_value="">913ec0e597e1711000989fa00153af05</trigger>
     </sys_trigger_runner_mapping>
-    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=4f42734997a1311000989fa00153afd0^sys_idNOT IN0de7c42197e1711000989fa00153afc5"/>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=4f42734997a1311000989fa00153afd0^sys_idNOT IN1d3ec0e597e1711000989fa00153af05"/>
     <sys_hub_trigger_instance action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0^sys_idNOT IN251cb7419725311000989fa00153af80"/>
     <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
         <comment/>
@@ -93,10 +93,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 18:46:01</sys_created_on>
         <sys_id>251cb7419725311000989fa00153af80</sys_id>
-        <sys_mod_count>5</sys_mod_count>
+        <sys_mod_count>12</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -139,10 +139,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 18:46:01</sys_created_on>
         <sys_id>6d1cb7419725311000989fa00153af81</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
-        <value>csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING</value>
+        <sys_updated_on>2023-09-27 14:40:00</sys_updated_on>
+        <value>csp_idISEMPTY^NQdashboard_linkISEMPTY</value>
         <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_a45d9180c32222002841b63b12d3aea7^id=251cb7419725311000989fa00153af80"/>
@@ -307,14 +307,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 18:46:01</sys_created_on>
         <sys_id>651cb7419725311000989fa00153af62</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -390,14 +390,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 18:46:01</sys_created_on>
         <sys_id>d91cfb0997e1311000989fa00153afdf</sys_id>
-        <sys_mod_count>1</sys_mod_count>
+        <sys_mod_count>5</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -427,10 +427,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 21:23:38</sys_created_on>
         <sys_id>5a20a85197a5311000989fa00153af0f</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>22</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <sys_updated_by>system</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:45:33</sys_updated_on>
         <ui_id>2d623107-02fe-4951-a607-585b96f20ffb</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=5a20a85197a5311000989fa00153af0f"/>
@@ -467,11 +467,11 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 21:23:38</sys_created_on>
         <sys_id>de20a85197a5311000989fa00153af11</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:23</sys_updated_on>
         <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
-        <value>csp_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}</value>
+        <value>hoth_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}^title={{Created or Updated_1.current.name}}</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=5a20a85197a5311000989fa00153af0f"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=5a20a85197a5311000989fa00153af0f"/>
@@ -489,10 +489,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 21:23:38</sys_created_on>
         <sys_id>9e20a85197a5311000989fa00153af15</sys_id>
-        <sys_mod_count>6</sys_mod_count>
+        <sys_mod_count>22</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <sys_updated_by>system</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:45:33</sys_updated_on>
         <ui_id>91b86259-fb3b-44d4-a8ec-6f14b2962604</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=9e20a85197a5311000989fa00153af15"/>
@@ -534,10 +534,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-26 21:23:38</sys_created_on>
         <sys_id>5a20a85197a5311000989fa00153af08</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <ui_id>7e0ec25f-cefa-4f7e-bd11-33bb8c88ca43</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -720,20 +720,20 @@
     <sys_flow_trigger_plan action="delete_multiple" query="plan_id=4f42734997a1311000989fa00153afd0^sys_idNOT INcde7c42197e1711000989fa00153afc6"/>
     <sys_flow_trigger_plan action="INSERT_OR_UPDATE">
         <binding_strategy>com.snc.process_flow.engine.binding.Every</binding_strategy>
-        <plan/>
+        <plan>{"persistor":{"@class":".ChunkingPlanPersistor","table":"sys_flow_trigger_plan","id":"cde7c42197e1711000989fa00153afc6","name":"plan","plan_signature":null}}</plan>
         <plan_id>4f42734997a1311000989fa00153afd0</plan_id>
-        <snapshot>20e7c42197e1711000989fa00153af24</snapshot>
+        <snapshot>38aec8e597e1711000989fa00153af58</snapshot>
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>cde7c42197e1711000989fa00153afc6</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_overrides/>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
-        <trigger display_value="">81e7c42197e1711000989fa00153afc5</trigger>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
+        <trigger display_value="">913ec0e597e1711000989fa00153af05</trigger>
     </sys_flow_trigger_plan>
     <sys_flow_subflow_plan action="delete_multiple" query="plan_id=4f42734997a1311000989fa00153afd0"/>
     <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
@@ -747,7 +747,7 @@
         <copied_from_name/>
         <description>Flow to retrieve CSP data pertaining to Portfolios, Task Orders, and Environments.</description>
         <internal_name>prov_get_portfolio</internal_name>
-        <label_cache>[{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}}]</label_cache>
+        <label_cache>[{"name":"Created or Updated_1.current.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_environment","column_name":"name"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","reference":"","reference_display":"","type":"string","base_type":"string","column_name":"","attributes":{"uiType":"string","uiTypeLabel":"String","element_mapping_provider":"com.glide.flow_design.action.data.FlowDesignVariableMapper","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"}]</label_cache>
         <master>true</master>
         <name>PROV: Get Portfolio</name>
         <natlang/>
@@ -764,7 +764,7 @@
         <sys_domain>global</sys_domain>
         <sys_domain_path>/</sys_domain_path>
         <sys_id>20e7c42197e1711000989fa00153af24</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_name/>
         <sys_overrides/>
         <sys_package/>
@@ -772,7 +772,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <type>flow</type>
     </sys_hub_flow_snapshot>
     <sys_translated_text action="delete_multiple" query="documentkey=20e7c42197e1711000989fa00153af24"/>
@@ -787,10 +787,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>bce7c42197e1711000989fa00153afae</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>8</sys_mod_count>
         <sys_scope/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:41</sys_updated_on>
         <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
         <trigger_inputs/>
         <trigger_outputs/>
@@ -833,10 +833,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>f8e7c42197e1711000989fa00153afb0</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
-        <value>csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING</value>
+        <sys_updated_on>2023-09-27 14:41:35</sys_updated_on>
+        <value>csp_idISEMPTY^NQdashboard_linkISEMPTY</value>
         <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
     </sys_variable_value>
     <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_a45d9180c32222002841b63b12d3aea7^id=bce7c42197e1711000989fa00153afae"/>
@@ -859,7 +859,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -918,14 +918,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:03</sys_created_on>
         <sys_id>78e7c42197e1711000989fa00153af58</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -942,7 +942,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -1001,14 +1001,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:03</sys_created_on>
         <sys_id>a4e7c42197e1711000989fa00153af26</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>3</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1025,7 +1025,7 @@
         <active>true</active>
         <array>false</array>
         <array_denormalized>false</array_denormalized>
-        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,co_type_name=FDCollection,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
         <audit>false</audit>
         <calculation><![CDATA[(function calculatedFieldValue(current) {
 
@@ -1084,14 +1084,14 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:03</sys_created_on>
         <sys_id>b4e7c42197e1711000989fa00153af50</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>1</sys_mod_count>
         <sys_name/>
         <sys_package/>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name/>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:41:35</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>
@@ -1121,10 +1121,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>70e7c42197e1711000989fa00153afa6</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <ui_id>2d623107-02fe-4951-a607-585b96f20ffb</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=70e7c42197e1711000989fa00153afa6"/>
@@ -1161,11 +1161,11 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>fce7c42197e1711000989fa00153afa7</sys_id>
-        <sys_mod_count>0</sys_mod_count>
+        <sys_mod_count>2</sys_mod_count>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
-        <value>csp_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}</value>
+        <value>hoth_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}^title={{Created or Updated_1.current.name}}</value>
     </sys_element_mapping>
     <sys_hub_input_scripts action="delete_multiple" query="instance=70e7c42197e1711000989fa00153afa6"/>
     <sys_hub_alias_mapping action="delete_multiple" query="source_id=70e7c42197e1711000989fa00153afa6"/>
@@ -1183,10 +1183,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>b4e7c42197e1711000989fa00153afad</sys_id>
-        <sys_mod_count>2</sys_mod_count>
+        <sys_mod_count>10</sys_mod_count>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <ui_id>91b86259-fb3b-44d4-a8ec-6f14b2962604</ui_id>
     </sys_hub_action_instance>
     <sys_variable_value action="delete_multiple" query="document_key=b4e7c42197e1711000989fa00153afad"/>
@@ -1228,10 +1228,10 @@
         <sys_created_by>admin</sys_created_by>
         <sys_created_on>2023-09-27 14:16:04</sys_created_on>
         <sys_id>f4e7c42197e1711000989fa00153af9d</sys_id>
-        <sys_mod_count>1</sys_mod_count>
-        <sys_scope/>
+        <sys_mod_count>6</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_updated_by>admin</sys_updated_by>
-        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <sys_updated_on>2023-09-27 14:43:40</sys_updated_on>
         <ui_id>7e0ec25f-cefa-4f7e-bd11-33bb8c88ca43</ui_id>
         <workflow_inputs/>
         <workflow_reference/>
@@ -1414,6 +1414,6 @@
     <sys_hub_flow action="UPDATE">
         <sys_id>4f42734997a1311000989fa00153afd0</sys_id>
         <latest_snapshot>20e7c42197e1711000989fa00153af24</latest_snapshot>
-        <compiler_build/>
+        <compiler_build>glide-tokyo-07-08-2022__patch9-hotfix2-06-07-2023_06-23-2023_1740.zip</compiler_build>
     </sys_hub_flow>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_4f42734997a1311000989fa00153afd0.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_hub_flow_4f42734997a1311000989fa00153afd0.xml
@@ -1,0 +1,1419 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update sys_domain="global" table="sys_hub_flow">
+    <sys_hub_flow action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <acls/>
+        <active>true</active>
+        <annotation/>
+        <callable_by_client_api>false</callable_by_client_api>
+        <category/>
+        <copied_from/>
+        <copied_from_name/>
+        <description>Flow to retrieve CSP data pertaining to Portfolios, Task Orders, and Environments.</description>
+        <internal_name>prov_get_portfolio</internal_name>
+        <label_cache>[{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}}]</label_cache>
+        <master_snapshot>20e7c42197e1711000989fa00153af24</master_snapshot>
+        <name>PROV: Get Portfolio</name>
+        <natlang/>
+        <outputs/>
+        <pre_compiled>false</pre_compiled>
+        <remote_trigger_id>81e7c42197e1711000989fa00153afc5</remote_trigger_id>
+        <run_as>system</run_as>
+        <run_with_roles/>
+        <sc_callable>false</sc_callable>
+        <show_draft_actions>false</show_draft_actions>
+        <show_triggered_flows>false</show_triggered_flows>
+        <status>published</status>
+        <sys_class_name>sys_hub_flow</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:03:15</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>4f42734997a1311000989fa00153afd0</sys_id>
+        <sys_mod_count>5</sys_mod_count>
+        <sys_name>PROV: Get Portfolio</sys_name>
+        <sys_overrides/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_4f42734997a1311000989fa00153afd0</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <type>flow</type>
+    </sys_hub_flow>
+    <sys_translated_text action="delete_multiple" query="documentkey=4f42734997a1311000989fa00153afd0"/>
+    <sys_variable_value action="delete_multiple" query="document_key=4f42734997a1311000989fa00153afd0"/>
+    <sys_flow_record_trigger action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <condition table="x_g_dis_atat_environment">csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING<item endquery="false" field="csp_id" goto="false" newquery="false" operator="EMPTYSTRING" or="false" value=""/>
+            <item endquery="false" field="dashboard_link" goto="false" newquery="true" operator="EMPTYSTRING" or="false" value=""/>
+        </condition>
+        <name/>
+        <on_delete>false</on_delete>
+        <on_insert>true</on_insert>
+        <on_update>true</on_update>
+        <run_flow_in>background</run_flow_in>
+        <run_on_extended>false</run_on_extended>
+        <run_when_setting>both</run_when_setting>
+        <run_when_user_list/>
+        <run_when_user_setting>any</run_when_user_setting>
+        <sys_class_name>sys_flow_record_trigger</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>81e7c42197e1711000989fa00153afc5</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_overrides/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table>x_g_dis_atat_environment</table>
+    </sys_flow_record_trigger>
+    <sys_trigger_runner_mapping action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <data>{"run_flow_in":"background","run_when_user_list":[],"run_when_setting":"both","run_when_user_setting":"any","run_on_extended":"false"}</data>
+        <identifier>4f42734997a1311000989fa00153afd0</identifier>
+        <runner>FDTriggerRunner</runner>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>0de7c42197e1711000989fa00153afc5</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <trigger display_value="">81e7c42197e1711000989fa00153afc5</trigger>
+    </sys_trigger_runner_mapping>
+    <sys_trigger_runner_mapping action="delete_multiple" query="identifier=4f42734997a1311000989fa00153afd0^sys_idNOT IN0de7c42197e1711000989fa00153afc5"/>
+    <sys_hub_trigger_instance action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0^sys_idNOT IN251cb7419725311000989fa00153af80"/>
+    <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</flow>
+        <name>Created or Updated</name>
+        <remote_sys_id/>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>251cb7419725311000989fa00153af80</sys_id>
+        <sys_mod_count>5</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
+        <trigger_inputs/>
+        <trigger_outputs/>
+        <trigger_type>record_create_or_update</trigger_type>
+    </sys_hub_trigger_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=251cb7419725311000989fa00153af80"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>251cb7419725311000989fa00153af80</document_key>
+        <order>1</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>211cb7419725311000989fa00153af82</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <value>x_g_dis_atat_environment</value>
+        <variable display_value="Table">cf1e1980c32222002841b63b12d3aea0</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>251cb7419725311000989fa00153af80</document_key>
+        <order>200</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>651cb7419725311000989fa00153af81</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <value>every</value>
+        <variable display_value="Run Trigger">2b9def50c31132002841b63b12d3ae5b</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>251cb7419725311000989fa00153af80</document_key>
+        <order>100</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>6d1cb7419725311000989fa00153af81</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <value>csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING</value>
+        <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_a45d9180c32222002841b63b12d3aea7^id=251cb7419725311000989fa00153af80"/>
+    <sys_hub_flow_stage action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0"/>
+    <sys_flow_cat_variable_model action="delete_multiple" query="id=4f42734997a1311000989fa00153afd0^sys_idNOT IN4b42734997a1311000989fa00153afd1"/>
+    <sys_flow_cat_variable_model action="INSERT_OR_UPDATE">
+        <id>4f42734997a1311000989fa00153afd0</id>
+        <name>PROV: Get Portfolio</name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:03:15</sys_created_on>
+        <sys_id>4b42734997a1311000989fa00153afd1</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:03:15</sys_updated_on>
+    </sys_flow_cat_variable_model>
+    <sys_flow_cat_variable action="delete_multiple" query="flow_catalog_model=4b42734997a1311000989fa00153afd1"/>
+    <sys_hub_flow_input action="delete_multiple" query="model=4f42734997a1311000989fa00153afd0^sys_idNOT IN2d1cb7419725311000989fa00153af5e,651cb7419725311000989fa00153af62,d91cfb0997e1311000989fa00153afdf"/>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,co_type_name=FDCollection,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>changed_fields</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Changed Fields</label>
+        <mandatory>false</mandatory>
+        <max_length>4000</max_length>
+        <model display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</model>
+        <model_id>4f42734997a1311000989fa00153afd0</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>2d1cb7419725311000989fa00153af5e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>table_name</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">table_name</internal_type>
+        <label>Table Name</label>
+        <mandatory>false</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</model>
+        <model_id>4f42734997a1311000989fa00153afd0</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <next_element/>
+        <order>101</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>651cb7419725311000989fa00153af62</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent>table_name</dependent>
+        <dependent_on_field>table_name</dependent_on_field>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>current</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">document_id</internal_type>
+        <label>Record</label>
+        <mandatory>true</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</model>
+        <model_id>4f42734997a1311000989fa00153afd0</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>d91cfb0997e1311000989fa00153afdf</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>true</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_output action="delete_multiple" query="model=4f42734997a1311000989fa00153afd0"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=4f42734997a1311000989fa00153afd0"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0^sys_idNOT IN5a20a85197a5311000989fa00153af0f,9e20a85197a5311000989fa00153af15"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Create Record">2de05916c31332002841b63b12d3aee1</action_type>
+        <action_type_parent/>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</flow>
+        <order>2</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>5a20a85197a5311000989fa00153af0f</sys_id>
+        <sys_mod_count>6</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <ui_id>2d623107-02fe-4951-a607-585b96f20ffb</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=5a20a85197a5311000989fa00153af0f"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_action_instance</document>
+        <document_key>5a20a85197a5311000989fa00153af0f</document_key>
+        <order>0</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>5220a85197a5311000989fa00153af12</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <value>x_g_dis_atat_provisioning_job</value>
+        <variable display_value="Table">61e05916c31332002841b63b12d3aee4</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="id=5a20a85197a5311000989fa00153af0f"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>table_name</field>
+        <id>5a20a85197a5311000989fa00153af0f</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>1a20a85197a5311000989fa00153af11</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value/>
+    </sys_element_mapping>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>values</field>
+        <id>5a20a85197a5311000989fa00153af0f</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>de20a85197a5311000989fa00153af11</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value>csp_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=5a20a85197a5311000989fa00153af0f"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=5a20a85197a5311000989fa00153af0f"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Log">5bc1bcc6531003003bf1d9109ec587d4</action_type>
+        <action_type_parent/>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</flow>
+        <order>3</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>9e20a85197a5311000989fa00153af15</sys_id>
+        <sys_mod_count>6</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:05</sys_updated_on>
+        <ui_id>91b86259-fb3b-44d4-a8ec-6f14b2962604</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=9e20a85197a5311000989fa00153af15"/>
+    <sys_element_mapping action="delete_multiple" query="id=9e20a85197a5311000989fa00153af15"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>log_message</field>
+        <id>9e20a85197a5311000989fa00153af15</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>d220a85197a5311000989fa00153af17</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
+        <value>Inserted Provisioning Job (Sys ID: {{2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id}}) of type {{2d623107-02fe-4951-a607-585b96f20ffb.record.job_type}} for Portfolio: {{Created or Updated_1.current.portfolio.name}} (Sys ID: {{Created or Updated_1.current.portfolio.sys_id}})</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=9e20a85197a5311000989fa00153af15"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=9e20a85197a5311000989fa00153af15"/>
+    <sys_hub_sub_flow_instance action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0"/>
+    <sys_hub_flow_logic action="delete_multiple" query="flow=4f42734997a1311000989fa00153afd0^sys_idNOT IN5a20a85197a5311000989fa00153af08"/>
+    <sys_hub_flow_logic action="INSERT_OR_UPDATE">
+        <block display_value="">5a20a85197a5311000989fa00153af07</block>
+        <comment/>
+        <connected_to/>
+        <decision_table/>
+        <decision_table_inputs/>
+        <display_text/>
+        <extended_inputs/>
+        <flow display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</flow>
+        <flow_variable/>
+        <flow_variables_assigned>hoth_job_id</flow_variables_assigned>
+        <inputs/>
+        <logic_definition display_value="Set Flow Variables">4f787d1e0f9b0010ecf0cc52ff767ea0</logic_definition>
+        <order>1</order>
+        <outputs_assigned/>
+        <outputs_to_assign/>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_flow_logic</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>5a20a85197a5311000989fa00153af08</sys_id>
+        <sys_mod_count>3</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <ui_id>7e0ec25f-cefa-4f7e-bd11-33bb8c88ca43</ui_id>
+        <workflow_inputs/>
+        <workflow_reference/>
+    </sys_hub_flow_logic>
+    <sys_variable_value action="delete_multiple" query="document_key=5a20a85197a5311000989fa00153af08"/>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_flow_variable_4f42734997a1311000989fa00153afd0^id=5a20a85197a5311000989fa00153af08"/>
+    <sys_hub_flow_logic_ext_input action="delete_multiple" query="model=5a20a85197a5311000989fa00153af08"/>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=5a20a85197a5311000989fa00153af08^sys_idNOT INda20a85197a5311000989fa00153af09"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>hoth_job_id</input_name>
+        <instance>5a20a85197a5311000989fa00153af08</instance>
+        <referenced_table>sys_hub_flow_logic</referenced_table>
+        <script>{"hoth_job_id":{"scriptActive":true,"script":"return gs.generateGUID();"}}</script>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>da20a85197a5311000989fa00153af09</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_pill_compound action="delete_multiple" query="attached_to=4f42734997a1311000989fa00153afd0"/>
+    <sys_hub_flow_variable action="delete_multiple" query="model=4f42734997a1311000989fa00153afd0^sys_idNOT IN5e20685197a5311000989fa00153affe"/>
+    <sys_hub_flow_variable action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=string,uiTypeLabel=String,uiUniqueId=704f203f-389c-427c-8b0b-93bf32e77134</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>hoth_job_id</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Hoth Job Id</label>
+        <mandatory>false</mandatory>
+        <max_length>8000</max_length>
+        <model display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</model>
+        <model_id>4f42734997a1311000989fa00153afd0</model_id>
+        <model_table>sys_hub_flow</model_table>
+        <name>var__m_sys_hub_flow_variable_4f42734997a1311000989fa00153afd0</name>
+        <next_element/>
+        <order>0</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_variable</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 21:23:38</sys_created_on>
+        <sys_id>5e20685197a5311000989fa00153affe</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Hoth Job Id</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_variable_5e20685197a5311000989fa00153affe</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 21:23:38</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_variable>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0^sys_idNOT IN651cb7419725311000989fa00153af5d,a51cb7419725311000989fa00153af61,a91cb7419725311000989fa00153af64"/>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>current</element>
+        <help/>
+        <hint/>
+        <label>Record</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>651cb7419725311000989fa00153af5d</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>changed_fields</element>
+        <help/>
+        <hint/>
+        <label>Changed Fields</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>a51cb7419725311000989fa00153af61</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>table_name</element>
+        <help/>
+        <hint/>
+        <label>Table Name</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-26 18:46:01</sys_created_on>
+        <sys_id>a91cb7419725311000989fa00153af64</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-26 18:46:01</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_input_4f42734997a1311000989fa00153afd0"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_output_4f42734997a1311000989fa00153afd0"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_4f42734997a1311000989fa00153afd0"/>
+    <sys_flow_trigger_plan action="delete_multiple" query="plan_id=4f42734997a1311000989fa00153afd0^sys_idNOT INcde7c42197e1711000989fa00153afc6"/>
+    <sys_flow_trigger_plan action="INSERT_OR_UPDATE">
+        <binding_strategy>com.snc.process_flow.engine.binding.Every</binding_strategy>
+        <plan/>
+        <plan_id>4f42734997a1311000989fa00153afd0</plan_id>
+        <snapshot>20e7c42197e1711000989fa00153af24</snapshot>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>cde7c42197e1711000989fa00153afc6</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_overrides/>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <trigger display_value="">81e7c42197e1711000989fa00153afc5</trigger>
+    </sys_flow_trigger_plan>
+    <sys_flow_subflow_plan action="delete_multiple" query="plan_id=4f42734997a1311000989fa00153afd0"/>
+    <sys_hub_flow_snapshot action="INSERT_OR_UPDATE">
+        <access>public</access>
+        <acls/>
+        <active>true</active>
+        <annotation/>
+        <callable_by_client_api>false</callable_by_client_api>
+        <category/>
+        <copied_from/>
+        <copied_from_name/>
+        <description>Flow to retrieve CSP data pertaining to Portfolios, Task Orders, and Environments.</description>
+        <internal_name>prov_get_portfolio</internal_name>
+        <label_cache>[{"name":"Created or Updated_1.current.portfolio.sys_id","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_portfolio","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio.name","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio➛Name","reference":"","reference_display":"Name","type":"string","base_type":"string","parent_table_name":"x_g_dis_atat_portfolio","column_name":"name"},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.job_type","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Job Type","reference":"","reference_display":"Job Type","type":"choice","base_type":"choice","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"job_type","choices":[{"label":"Add Administrator to Environment","used":false,"image":"","reference":false,"rawLabel":"Add Administrator to Environment","selected":false,"missing":false,"value":"ADD_ADMINISTRATOR","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Environment","used":false,"image":"","reference":false,"rawLabel":"Add New Environment","selected":false,"missing":false,"value":"ADD_ENVIRONMENT","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add New Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add New Portfolio","selected":false,"missing":false,"value":"ADD_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Add Task Order to Portfolio","used":false,"image":"","reference":false,"rawLabel":"Add Task Order to Portfolio","selected":false,"missing":false,"value":"ADD_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Get Existing Portfolio","used":false,"image":"","reference":false,"rawLabel":"Get Existing Portfolio","selected":false,"missing":false,"value":"GET_PORTFOLIO","parameters":{"name":"x_g_dis_atat_provisioning_job"}},{"label":"Update Task Order in Portfolio","used":false,"image":"","reference":false,"rawLabel":"Update Task Order in Portfolio","selected":false,"missing":false,"value":"UPDATE_TASK_ORDER","parameters":{"name":"x_g_dis_atat_provisioning_job"}}]},{"name":"2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id","label":"2 - Create Record➛ATAT:Provisioning Job Record➛Sys ID","reference":"","reference_display":"Sys ID","type":"GUID","base_type":"GUID","parent_table_name":"x_g_dis_atat_provisioning_job","column_name":"sys_id"},{"name":"Created or Updated_1.current.portfolio","label":"Trigger - Record Created or Updated➛ATAT:Environment Record➛Portfolio","reference":"x_g_dis_atat_portfolio","reference_display":"ATAT:Portfolio","type":"reference","base_type":"reference","parent_table_name":"x_g_dis_atat_environment","column_name":"portfolio"},{"name":"flow_variable.hoth_job_id","label":"Flow Variables➛Hoth Job Id","type":"string","base_type":"string","attributes":{"sourceUiUniqueId":"","sourceType":"","sourceId":"","uiUniqueId":"704f203f-389c-427c-8b0b-93bf32e77134"}}]</label_cache>
+        <master>true</master>
+        <name>PROV: Get Portfolio</name>
+        <natlang/>
+        <outputs/>
+        <parent_flow display_value="PROV: Get Portfolio">4f42734997a1311000989fa00153afd0</parent_flow>
+        <remote_trigger_id/>
+        <run_as>system</run_as>
+        <run_with_roles/>
+        <sc_callable>false</sc_callable>
+        <status>published</status>
+        <sys_class_name>sys_hub_flow_snapshot</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_domain>global</sys_domain>
+        <sys_domain_path>/</sys_domain_path>
+        <sys_id>20e7c42197e1711000989fa00153af24</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_overrides/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <type>flow</type>
+    </sys_hub_flow_snapshot>
+    <sys_translated_text action="delete_multiple" query="documentkey=20e7c42197e1711000989fa00153af24"/>
+    <sys_variable_value action="delete_multiple" query="document_key=20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_trigger_instance action="delete_multiple" query="flow=20e7c42197e1711000989fa00153af24^sys_idNOT INbce7c42197e1711000989fa00153afae"/>
+    <sys_hub_trigger_instance action="INSERT_OR_UPDATE">
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</flow>
+        <name>Created or Updated</name>
+        <remote_sys_id/>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>bce7c42197e1711000989fa00153afae</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <trigger_definition display_value="Created or Updated">a45d9180c32222002841b63b12d3aea7</trigger_definition>
+        <trigger_inputs/>
+        <trigger_outputs/>
+        <trigger_type>record_create_or_update</trigger_type>
+    </sys_hub_trigger_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=bce7c42197e1711000989fa00153afae"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>bce7c42197e1711000989fa00153afae</document_key>
+        <order>200</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>38e7c42197e1711000989fa00153afb0</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <value>every</value>
+        <variable display_value="Run Trigger">2b9def50c31132002841b63b12d3ae5b</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>bce7c42197e1711000989fa00153afae</document_key>
+        <order>1</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>bce7c42197e1711000989fa00153afb0</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <value>x_g_dis_atat_environment</value>
+        <variable display_value="Table">cf1e1980c32222002841b63b12d3aea0</variable>
+    </sys_variable_value>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_trigger_instance</document>
+        <document_key>bce7c42197e1711000989fa00153afae</document_key>
+        <order>100</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>f8e7c42197e1711000989fa00153afb0</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <value>csp_idEMPTYSTRING^NQdashboard_linkEMPTYSTRING</value>
+        <variable display_value="Condition">707dd180c32222002841b63b12d3aecb</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_trigger_output_a45d9180c32222002841b63b12d3aea7^id=bce7c42197e1711000989fa00153afae"/>
+    <sys_hub_flow_stage action="delete_multiple" query="flow=20e7c42197e1711000989fa00153af24"/>
+    <sys_flow_cat_variable_model action="delete_multiple" query="id=20e7c42197e1711000989fa00153af24^sys_idNOT IN20e7c42197e1711000989fa00153af25"/>
+    <sys_flow_cat_variable_model action="INSERT_OR_UPDATE">
+        <id>20e7c42197e1711000989fa00153af24</id>
+        <name>PROV: Get Portfolio</name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>20e7c42197e1711000989fa00153af25</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+    </sys_flow_cat_variable_model>
+    <sys_flow_cat_variable action="delete_multiple" query="flow_catalog_model=20e7c42197e1711000989fa00153af25"/>
+    <sys_hub_flow_input action="delete_multiple" query="model=20e7c42197e1711000989fa00153af24^sys_idNOT IN78e7c42197e1711000989fa00153af58,a4e7c42197e1711000989fa00153af26,b4e7c42197e1711000989fa00153af50"/>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,test_input_hidden=true,uiType=table_name,uiTypeLabel=Table Name</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>table_name</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">table_name</internal_type>
+        <label>Table Name</label>
+        <mandatory>false</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</model>
+        <model_id>20e7c42197e1711000989fa00153af24</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <next_element/>
+        <order>101</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>78e7c42197e1711000989fa00153af58</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=document_id,uiTypeLabel=Document ID</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent>table_name</dependent>
+        <dependent_on_field>table_name</dependent_on_field>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>current</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="">document_id</internal_type>
+        <label>Record</label>
+        <mandatory>true</mandatory>
+        <max_length>200</max_length>
+        <model display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</model>
+        <model_id>20e7c42197e1711000989fa00153af24</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>a4e7c42197e1711000989fa00153af26</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>true</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_input action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>child_label=FDChangeDetails,child_name=FDChangeDetails,child_type=object,child_type_label=Object,element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,pwd2droppable=true,uiType=array.object,uiTypeLabel=Array.Object</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>changed_fields</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Changed Fields</label>
+        <mandatory>false</mandatory>
+        <max_length>4000</max_length>
+        <model display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</model>
+        <model_id>20e7c42197e1711000989fa00153af24</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <next_element/>
+        <order>100</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_input</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>b4e7c42197e1711000989fa00153af50</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package/>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_input>
+    <sys_hub_flow_output action="delete_multiple" query="model=20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_action_instance action="delete_multiple" query="flow=20e7c42197e1711000989fa00153af24^sys_idNOT IN70e7c42197e1711000989fa00153afa6,b4e7c42197e1711000989fa00153afad"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Create Record">2de05916c31332002841b63b12d3aee1</action_type>
+        <action_type_parent display_value="Create Record">02f0b88cc3c632002841b63b12d3aeff</action_type_parent>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</flow>
+        <order>2</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>70e7c42197e1711000989fa00153afa6</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <ui_id>2d623107-02fe-4951-a607-585b96f20ffb</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=70e7c42197e1711000989fa00153afa6"/>
+    <sys_variable_value action="INSERT_OR_UPDATE">
+        <document>sys_hub_action_instance</document>
+        <document_key>70e7c42197e1711000989fa00153afa6</document_key>
+        <order>0</order>
+        <sys_class_name>sys_variable_value</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>70e7c42197e1711000989fa00153afa8</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <value>x_g_dis_atat_provisioning_job</value>
+        <variable display_value="Table">61e05916c31332002841b63b12d3aee4</variable>
+    </sys_variable_value>
+    <sys_element_mapping action="delete_multiple" query="id=70e7c42197e1711000989fa00153afa6"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>table_name</field>
+        <id>70e7c42197e1711000989fa00153afa6</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>38e7c42197e1711000989fa00153afa7</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value/>
+    </sys_element_mapping>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>values</field>
+        <id>70e7c42197e1711000989fa00153afa6</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>fce7c42197e1711000989fa00153afa7</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table>var__m_sys_hub_action_input_2de05916c31332002841b63b12d3aee1</table>
+        <value>csp_job_id={{flow_variable.hoth_job_id}}^job_type=GET_PORTFOLIO^portfolio={{Created or Updated_1.current.portfolio}}</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=70e7c42197e1711000989fa00153afa6"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=70e7c42197e1711000989fa00153afa6"/>
+    <sys_hub_action_instance action="INSERT_OR_UPDATE">
+        <action_inputs/>
+        <action_inputs/>
+        <action_type display_value="Log">5bc1bcc6531003003bf1d9109ec587d4</action_type>
+        <action_type_parent display_value="Log">0e0ae8c2531003003bf1d9109ec587c8</action_type_parent>
+        <comment/>
+        <display_text/>
+        <flow display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</flow>
+        <order>3</order>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_action_instance</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>b4e7c42197e1711000989fa00153afad</sys_id>
+        <sys_mod_count>2</sys_mod_count>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <ui_id>91b86259-fb3b-44d4-a8ec-6f14b2962604</ui_id>
+    </sys_hub_action_instance>
+    <sys_variable_value action="delete_multiple" query="document_key=b4e7c42197e1711000989fa00153afad"/>
+    <sys_element_mapping action="delete_multiple" query="id=b4e7c42197e1711000989fa00153afad"/>
+    <sys_element_mapping action="INSERT_OR_UPDATE">
+        <field>log_message</field>
+        <id>b4e7c42197e1711000989fa00153afad</id>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>78e7c42197e1711000989fa00153afae</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table>var__m_sys_hub_action_input_5bc1bcc6531003003bf1d9109ec587d4</table>
+        <value>Inserted Provisioning Job (Sys ID: {{2d623107-02fe-4951-a607-585b96f20ffb.record.sys_id}}) of type {{2d623107-02fe-4951-a607-585b96f20ffb.record.job_type}} for Portfolio: {{Created or Updated_1.current.portfolio.name}} (Sys ID: {{Created or Updated_1.current.portfolio.sys_id}})</value>
+    </sys_element_mapping>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=b4e7c42197e1711000989fa00153afad"/>
+    <sys_hub_alias_mapping action="delete_multiple" query="source_id=b4e7c42197e1711000989fa00153afad"/>
+    <sys_hub_sub_flow_instance action="delete_multiple" query="flow=20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_flow_logic action="delete_multiple" query="flow=20e7c42197e1711000989fa00153af24^sys_idNOT INf4e7c42197e1711000989fa00153af9d"/>
+    <sys_hub_flow_logic action="INSERT_OR_UPDATE">
+        <block display_value="">5a20a85197a5311000989fa00153af07</block>
+        <comment/>
+        <connected_to/>
+        <decision_table/>
+        <decision_table_inputs/>
+        <display_text/>
+        <extended_inputs/>
+        <flow display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</flow>
+        <flow_variable/>
+        <flow_variables_assigned>hoth_job_id</flow_variables_assigned>
+        <inputs/>
+        <logic_definition display_value="Set Flow Variables">4f787d1e0f9b0010ecf0cc52ff767ea0</logic_definition>
+        <order>1</order>
+        <outputs_assigned/>
+        <outputs_to_assign/>
+        <parent_ui_id/>
+        <sys_class_name>sys_hub_flow_logic</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>f4e7c42197e1711000989fa00153af9d</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_scope/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <ui_id>7e0ec25f-cefa-4f7e-bd11-33bb8c88ca43</ui_id>
+        <workflow_inputs/>
+        <workflow_reference/>
+    </sys_hub_flow_logic>
+    <sys_variable_value action="delete_multiple" query="document_key=f4e7c42197e1711000989fa00153af9d"/>
+    <sys_element_mapping action="delete_multiple" query="table=var__m_sys_hub_flow_variable_20e7c42197e1711000989fa00153af24^id=f4e7c42197e1711000989fa00153af9d"/>
+    <sys_hub_flow_logic_ext_input action="delete_multiple" query="model=f4e7c42197e1711000989fa00153af9d"/>
+    <sys_hub_input_scripts action="delete_multiple" query="instance=f4e7c42197e1711000989fa00153af9d^sys_idNOT INb8e7c42197e1711000989fa00153af9e"/>
+    <sys_hub_input_scripts action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <input_name>hoth_job_id</input_name>
+        <instance>f4e7c42197e1711000989fa00153af9d</instance>
+        <referenced_table>sys_hub_flow_logic</referenced_table>
+        <script>{"hoth_job_id":{"scriptActive":true,"script":"return gs.generateGUID();"}}</script>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>b8e7c42197e1711000989fa00153af9e</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+    </sys_hub_input_scripts>
+    <sys_hub_pill_compound action="delete_multiple" query="attached_to=20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_flow_variable action="delete_multiple" query="model=20e7c42197e1711000989fa00153af24^sys_idNOT IN38e7c42197e1711000989fa00153af8b"/>
+    <sys_hub_flow_variable action="INSERT_OR_UPDATE">
+        <active>true</active>
+        <array>false</array>
+        <array_denormalized>false</array_denormalized>
+        <attributes>element_mapping_provider=com.glide.flow_design.action.data.FlowDesignVariableMapper,uiType=string,uiTypeLabel=String,uiUniqueId=704f203f-389c-427c-8b0b-93bf32e77134</attributes>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice/>
+        <choice_field/>
+        <choice_table/>
+        <column_label/>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>hoth_job_id</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <help/>
+        <hint/>
+        <internal_type display_value="String">string</internal_type>
+        <label>Hoth Job Id</label>
+        <mandatory>false</mandatory>
+        <max_length>8000</max_length>
+        <model display_value="PROV: Get Portfolio">20e7c42197e1711000989fa00153af24</model>
+        <model_id>20e7c42197e1711000989fa00153af24</model_id>
+        <model_table>sys_hub_flow_snapshot</model_table>
+        <name>var__m_sys_hub_flow_variable_20e7c42197e1711000989fa00153af24</name>
+        <next_element/>
+        <order>0</order>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <sizeclass/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_hub_flow_variable</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:04</sys_created_on>
+        <sys_id>38e7c42197e1711000989fa00153af8b</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>Hoth Job Id</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_hub_flow_variable_38e7c42197e1711000989fa00153af8b</sys_update_name>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:04</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_hub_flow_variable>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24^sys_idNOT IN30e7c42197e1711000989fa00153af55,38e7c42197e1711000989fa00153af4c,70e7c42197e1711000989fa00153af5d"/>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>changed_fields</element>
+        <help/>
+        <hint/>
+        <label>Changed Fields</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>30e7c42197e1711000989fa00153af55</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>current</element>
+        <help/>
+        <hint/>
+        <label>Record</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>38e7c42197e1711000989fa00153af4c</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_documentation action="INSERT_OR_UPDATE">
+        <element>table_name</element>
+        <help/>
+        <hint/>
+        <label>Table Name</label>
+        <language>en</language>
+        <name>var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24</name>
+        <plural/>
+        <sys_class_name>sys_documentation</sys_class_name>
+        <sys_created_by>admin</sys_created_by>
+        <sys_created_on>2023-09-27 14:16:03</sys_created_on>
+        <sys_id>70e7c42197e1711000989fa00153af5d</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name/>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name/>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-09-27 14:16:03</sys_updated_on>
+        <url/>
+        <url_target/>
+    </sys_documentation>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_input_20e7c42197e1711000989fa00153af24"/>
+    <sys_documentation action="delete_multiple" query="name=var__m_sys_hub_flow_output_20e7c42197e1711000989fa00153af24"/>
+    <sys_choice action="delete_multiple" query="name=var__m_sys_hub_flow_output_20e7c42197e1711000989fa00153af24"/>
+    <sys_hub_flow action="UPDATE">
+        <sys_id>4f42734997a1311000989fa00153afd0</sys_id>
+        <latest_snapshot>20e7c42197e1711000989fa00153af24</latest_snapshot>
+        <compiler_build/>
+    </sys_hub_flow>
+</record_update>


### PR DESCRIPTION
Created new Flow to add a record to the `ATAT: Provisioning Job` table. The job is triggered on an update or creation of records in the `ATAT: Environment` table with an empty `csp_id` or `dashboard_link`.
![image](https://github.com/dod-ccpo/atat-snow/assets/138718699/0afd617e-bdbb-4785-9580-2fab0b083ff6)

