### PR TITLE
feature/AT-9553-summary-api

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_cdc93cc84761311039634aff336d4316.xml
@@ -30,7 +30,7 @@ GetUserPortfolios.prototype = {
 	getAgency: function(id) {
 		let gr = new GlideRecord(this.AGENCY_TABLE);
 		gr.get(id);
-		return gr.title.toString();
+		return gr;
 	},
 	getTODetails: function(toId){
 		let gr = new GlideRecord(this.TASK_ORDER_TABLE);
@@ -86,10 +86,11 @@ GetUserPortfolios.prototype = {
         while(gr.next()){
 			let toDetails = this.getTODetails(gr.active_task_order.sys_id);
 			let clinDetails = this.getCLINData(gr.active_task_order.sys_id);
+			const agency = this.getAgency(gr.agency);
 			let portfolio = {
 				portfolio_name: gr.name.toString(),
 				portfolio_status: gr.portfolio_status.toString(),
-				agency: this.getAgency(gr.agency),
+				agency: agency.acronym,
 				last_updated: gr.last_updated,
 				current_user_is_owner: gr.portfolio_owner.toString() === this.userId ? true : false, 
 				current_user_is_manager: JSON.stringify(gr.portfolio_managers.toString()).includes(this.userId) ? true: false,
@@ -101,11 +102,12 @@ GetUserPortfolios.prototype = {
 				active_task_order: gr.active_task_order.getDisplayValue().toString(),
 				owner_full_name: gr.portfolio_owner.getDisplayValue().toString(),
 				funding_status: gr.portfolio_funding_status.toString(),
-				csp_portal_links: this.getCSPLinks(gr.sys_id)
+				csp_portal_links: this.getCSPLinks(gr.sys_id),
+				sys_id: gr.sys_id.toString()
 			};
             data.push(portfolio);
         }
-
+		
         return data;
 	},
 
@@ -115,13 +117,13 @@ GetUserPortfolios.prototype = {
         <sys_created_by>tom.arnold</sys_created_by>
         <sys_created_on>2023-09-23 02:03:45</sys_created_on>
         <sys_id>cdc93cc84761311039634aff336d4316</sys_id>
-        <sys_mod_count>68</sys_mod_count>
+        <sys_mod_count>69</sys_mod_count>
         <sys_name>GetUserPortfolios</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_cdc93cc84761311039634aff336d4316</sys_update_name>
-        <sys_updated_by>tom.arnold</sys_updated_by>
-        <sys_updated_on>2023-09-25 23:50:00</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-10-05 20:06:46</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_d5b5820447a5311039634aff336d4308.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_d5b5820447a5311039634aff336d4308.xml
@@ -26,11 +26,22 @@
         let PORTFOLIO_TABLE = "x_g_dis_atat_portfolio";
 		const port = new GetUserPortfolios(userId);
 		let portfolios = port.getPortfolioDetails();
+		const portfolioGA = new GlideAggregate(PORTFOLIO_TABLE);
+		portfolioGA.addAggregate('COUNT');
+		portfolioGA.addQuery('portfolio_owner', '=', userId)
+			.addOrCondition('portfolio_managers', 'CONTAINS', userId)
+			.addOrCondition('portfolio_viewers', 'CONTAINS', userId);
+		portfolioGA.query();
+		let count = 0;
+		while (portfolioGA.next()) {
+			count = portfolioGA.getAggregate('COUNT');
+		}
 		response.setStatus(200);
 		response.setContentType('application/json');
 		response.setBody({
-			"Portfolios": portfolios,
-			"userId": userId
+			"portfolios": portfolios,
+			"userId": userId,
+			"portfolioCount": count
 		});
     } 
   } catch (err) {
@@ -56,14 +67,14 @@
         <sys_created_by>tom.arnold</sys_created_by>
         <sys_created_on>2023-09-23 07:37:02</sys_created_on>
         <sys_id>d5b5820447a5311039634aff336d4308</sys_id>
-        <sys_mod_count>3</sys_mod_count>
+        <sys_mod_count>4</sys_mod_count>
         <sys_name>Summary</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_ws_operation_d5b5820447a5311039634aff336d4308</sys_update_name>
-        <sys_updated_by>tom.arnold</sys_updated_by>
-        <sys_updated_on>2023-09-24 20:59:22</sys_updated_on>
+        <sys_updated_by>admin</sys_updated_by>
+        <sys_updated_on>2023-10-05 20:06:22</sys_updated_on>
         <web_service_definition display_value="Portfolios">5256ec484721311039634aff336d43e8</web_service_definition>
         <web_service_version/>
     </sys_ws_operation>


### PR DESCRIPTION
Just edited the new portfolio summary API to give back sys_id of the portfolios and the agency acronym.
![image](https://github.com/dod-ccpo/atat-snow/assets/139161354/cb604e80-32a0-4a3d-bad9-cbcb2b600ab5)


Also moved the count aggregate into the call instead of making that from the frontend
![image](https://github.com/dod-ccpo/atat-snow/assets/139161354/596281ca-6ddc-49ed-81e6-f740c78495c6)
