### PR TITLE
feature/AT-9836 now defaults to TBD

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_324825d997a7d5106fa8b4b3f153af7c.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_324825d997a7d5106fa8b4b3f153af7c.xml
@@ -14,9 +14,15 @@ RequirementsChecklist.prototype = {
 	errUtil: new ErrorHandler(),
 	atatUtil: new AtatHelper(),
 	acquisitionPackage: null,
+	fundingRequest: null,
+	fsForm: null,
 
 	initialize: function(acqPackage) {
 		this.acquisitionPackage = acqPackage;
+		this.fundingRequest = new GlideRecord("x_g_dis_atat_funding_request");
+		this.fsForm = new GlideRecord("x_g_dis_atat_funding_request_fs_form");
+		this.fundingRequest.get(this.acquisitionPackage.funding_request);
+		this.fsForm.get(this.fundingRequest.fs_form);
 	},
 	mapPeriods: function(periods) {
 		return periods.map(function(period) {
@@ -120,6 +126,7 @@ RequirementsChecklist.prototype = {
 			return {
 				documentType: "REQUIREMENTS_CHECKLIST",
 				templatePayload: {
+					gtcNumber: this.fsForm.gt_c_number.toString() || "TBD",
 					projectOverview: {
 						title: acqPackage.project_overview.title.toString(),
 						scope: acqPackage.project_overview.scope.toString(),
@@ -185,13 +192,13 @@ RequirementsChecklist.prototype = {
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2022-12-02 20:50:47</sys_created_on>
         <sys_id>324825d997a7d5106fa8b4b3f153af7c</sys_id>
-        <sys_mod_count>73</sys_mod_count>
+        <sys_mod_count>76</sys_mod_count>
         <sys_name>RequirementsChecklist</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_324825d997a7d5106fa8b4b3f153af7c</sys_update_name>
-        <sys_updated_by>andrew.nickerl</sys_updated_by>
-        <sys_updated_on>2023-06-29 15:26:01</sys_updated_on>
+        <sys_updated_by>torin.harthcock</sys_updated_by>
+        <sys_updated_on>2023-10-10 01:04:38</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_5070b8dc976fd1106fa8b4b3f153afdd.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_5070b8dc976fd1106fa8b4b3f153afdd.xml
@@ -52,14 +52,14 @@ Ifp.prototype = {
 			// Return a schema-compliant empty object if we don't have a Funding Request (remove this once UI supports saving one)
 			if (!fundingRequest) {
 				return {
-					fundingType: "FS_FORM",
+					fundingType: "TBD",
 					orderNumber: "TBD"
 				};
 			}
 			var fundingType = fundingRequest.funding_request_type.toString();
 			if (!fundingType) {
 				return {
-					fundingType: "FS_FORM",
+					fundingType: "TBD",
 					orderNumber: "TBD"
 				};
 			}
@@ -67,7 +67,7 @@ Ifp.prototype = {
 			if (fundingType == "MIPR") {
 				return {
 					fundingType: fundingType,
-					miprNumber: fundingRequest.mipr.mipr_number ? fundingRequest.mipr.mipr_number.toString() : "",
+					miprNumber: fundingRequest.mipr.mipr_number ? fundingRequest.mipr.mipr_number.toString() : "TBD",
 				};
 			}
 
@@ -198,13 +198,13 @@ Ifp.prototype = {
         <sys_created_by>julius.fitzhugh-ctr</sys_created_by>
         <sys_created_on>2022-11-29 14:21:01</sys_created_on>
         <sys_id>5070b8dc976fd1106fa8b4b3f153afdd</sys_id>
-        <sys_mod_count>66</sys_mod_count>
+        <sys_mod_count>67</sys_mod_count>
         <sys_name>Ifp</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_5070b8dc976fd1106fa8b4b3f153afdd</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-08-04 21:22:11</sys_updated_on>
+        <sys_updated_on>2023-10-10 01:50:47</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_b29002b097a211106fa8b4b3f153afc4.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_b29002b097a211106fa8b4b3f153afc4.xml
@@ -939,13 +939,13 @@ Igce.prototype = {
             if (fundingRequest.funding_request_type == "MIPR") {
                 fundingDocument = {
                     fundingType: fundingRequest.funding_request_type.toString(),
-                    miprNumber: fundingRequest.mipr.mipr_number ? fundingRequest.mipr.mipr_number.toString() : ""
+                    miprNumber: fundingRequest.mipr.mipr_number ? fundingRequest.mipr.mipr_number.toString() : "TBD"
                 };
             } else if (fundingRequest.funding_request_type == "FS_FORM") {
                 fundingDocument = {
                     fundingType: fundingRequest.funding_request_type ? fundingRequest.funding_request_type.toString() : '',
-                    gtcNumber: fundingRequest.fs_form.gt_c_number ? fundingRequest.fs_form.gt_c_number.toString() : '',
-                    orderNumber: fundingRequest.fs_form.order_number ? fundingRequest.fs_form.order_number.toString() : "",
+                    gtcNumber: fundingRequest.fs_form.gt_c_number ? fundingRequest.fs_form.gt_c_number.toString() : 'TBD',
+                    orderNumber: fundingRequest.fs_form.order_number ? fundingRequest.fs_form.order_number.toString() : "TBD",
                 };
             }
         }
@@ -1384,13 +1384,13 @@ Igce.prototype = {
         <sys_created_by>jeff.segal-ctr</sys_created_by>
         <sys_created_on>2022-10-12 15:53:33</sys_created_on>
         <sys_id>b29002b097a211106fa8b4b3f153afc4</sys_id>
-        <sys_mod_count>144</sys_mod_count>
+        <sys_mod_count>145</sys_mod_count>
         <sys_name>Igce</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_b29002b097a211106fa8b4b3f153afc4</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-08-04 21:40:54</sys_updated_on>
+        <sys_updated_on>2023-10-10 02:01:14</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f252b5f3dbaa65108c045e8cd3961989.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_f252b5f3dbaa65108c045e8cd3961989.xml
@@ -79,7 +79,7 @@ JustificationAndApproval.prototype = {
 	
 	getPurchaseRequestNumber: function() {
 		if (!this.fundingRequest.funding_request_type) {
-			return "";
+			return "TBD";
 		}
 		else if (this.fundingRequest.funding_request_type.toString() == "MIPR") {
 			var mipr = new GlideRecord("x_g_dis_atat_funding_request_mipr");
@@ -89,7 +89,7 @@ JustificationAndApproval.prototype = {
 			}
 			else {				
 				if (!mipr.mipr_number) {
-					return "";				
+					return "TBD";				
 				}
 				else {
 					return mipr.mipr_number.toString();
@@ -100,7 +100,7 @@ JustificationAndApproval.prototype = {
 			var fsForm = new GlideRecord("x_g_dis_atat_funding_request_fs_form");
 			fsForm.get(this.fundingRequest.fs_form);
 			if (!fsForm.sys_id) {
-				return "";
+				return "TBD";
 			}
 			else {	
 				// TODO re-enable this validation once we properly parse G-Invoicing numbers (AT-9074)
@@ -110,7 +110,7 @@ JustificationAndApproval.prototype = {
 				//else {
 				//	return fsForm.order_number.toString();
 				//}
-				return fsForm.gt_c_number.toString() + (fsForm.order_number ? ", " + fsForm.order_number.toString() : "");
+				return  fsForm.order_number ? fsForm.order_number.toString() : "TBD";
 			}
 		}
 		else {
@@ -246,13 +246,13 @@ JustificationAndApproval.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-05-08 18:48:55</sys_created_on>
         <sys_id>f252b5f3dbaa65108c045e8cd3961989</sys_id>
-        <sys_mod_count>100</sys_mod_count>
+        <sys_mod_count>101</sys_mod_count>
         <sys_name>JustificationAndApproval</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_f252b5f3dbaa65108c045e8cd3961989</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-08-04 21:28:18</sys_updated_on>
+        <sys_updated_on>2023-10-10 02:16:54</sys_updated_on>
     </sys_script_include>
 </record_update>


### PR DESCRIPTION
Requirement Checklist, IFP, IGCE, and J&A will now default to TBD for funding information rather than empty string. Additionally, GTC number has been added to Requirements Checklist: 
![image](https://github.com/dod-ccpo/atat-snow/assets/137221301/f5da664e-0a6c-4d0c-bc25-91057e50af1b)

files can be tested by running the gather doc info actions:
![image](https://github.com/dod-ccpo/atat-snow/assets/137221301/4718f1cc-0975-4a28-92a3-f050a5bd83bf)

This is paired with an API PR: https://github.com/dod-ccpo/atat-web-api/pull/1858