### PR TITLE
feature/AT-9829 + AT-9831 - Step 8 - 7600a and 7600b

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
@@ -15,45 +15,5 @@
             <sys_updated_by>david.pietrzak</sys_updated_by>
             <sys_updated_on>2023-10-10 13:35:03</sys_updated_on>
         </sys_choice_set>
-        <sys_choice action="INSERT_OR_UPDATE">
-            <dependent_value/>
-            <element>fs_form_7600a_use_g_invoicing</element>
-            <hint/>
-            <inactive>false</inactive>
-            <label>NO</label>
-            <language>en</language>
-            <name>x_g_dis_atat_funding_request_fs_form</name>
-            <sequence/>
-            <synonyms/>
-            <sys_created_by>david.pietrzak</sys_created_by>
-            <sys_created_on>2023-10-10 13:36:56</sys_created_on>
-            <sys_domain>global</sys_domain>
-            <sys_domain_path>/</sys_domain_path>
-            <sys_id>159b72e997713110aba7325e6253af43</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_updated_by>david.pietrzak</sys_updated_by>
-            <sys_updated_on>2023-10-10 13:36:56</sys_updated_on>
-            <value>NO</value>
-        </sys_choice>
-        <sys_choice action="INSERT_OR_UPDATE">
-            <dependent_value/>
-            <element>fs_form_7600a_use_g_invoicing</element>
-            <hint/>
-            <inactive>false</inactive>
-            <label>YES</label>
-            <language>en</language>
-            <name>x_g_dis_atat_funding_request_fs_form</name>
-            <sequence/>
-            <synonyms/>
-            <sys_created_by>david.pietrzak</sys_created_by>
-            <sys_created_on>2023-10-10 13:36:38</sys_created_on>
-            <sys_domain>global</sys_domain>
-            <sys_domain_path>/</sys_domain_path>
-            <sys_id>fa7bf6e997713110aba7325e6253af11</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_updated_by>david.pietrzak</sys_updated_by>
-            <sys_updated_on>2023-10-10 13:36:38</sys_updated_on>
-            <value>YES</value>
-        </sys_choice>
     </sys_choice>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_choice action="INSERT_OR_UPDATE" field="fs_form_7600a_use_g_invoicing" table="x_g_dis_atat_funding_request_fs_form" version="3">
+        <sys_choice_set action="INSERT_OR_UPDATE">
+            <element>fs_form_7600a_use_g_invoicing</element>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sys_class_name>sys_choice_set</sys_class_name>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:35:03</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>fs_form_7600a_use_g_invoicing</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing</sys_update_name>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:35:03</sys_updated_on>
+        </sys_choice_set>
+        <sys_choice action="INSERT_OR_UPDATE">
+            <dependent_value/>
+            <element>fs_form_7600a_use_g_invoicing</element>
+            <hint/>
+            <inactive>false</inactive>
+            <label>NO</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sequence/>
+            <synonyms/>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:36:56</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>159b72e997713110aba7325e6253af43</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:36:56</sys_updated_on>
+            <value>NO</value>
+        </sys_choice>
+        <sys_choice action="INSERT_OR_UPDATE">
+            <dependent_value/>
+            <element>fs_form_7600a_use_g_invoicing</element>
+            <hint/>
+            <inactive>false</inactive>
+            <label>YES</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sequence/>
+            <synonyms/>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:36:38</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>fa7bf6e997713110aba7325e6253af11</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:36:38</sys_updated_on>
+            <value>YES</value>
+        </sys_choice>
+    </sys_choice>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_choice action="INSERT_OR_UPDATE" field="fs_form_7600b_use_g_invoicing" table="x_g_dis_atat_funding_request_fs_form" version="3">
+        <sys_choice_set action="INSERT_OR_UPDATE">
+            <element>fs_form_7600b_use_g_invoicing</element>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sys_class_name>sys_choice_set</sys_class_name>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:38:25</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>fs_form_7600b_use_g_invoicing</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing</sys_update_name>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:38:25</sys_updated_on>
+        </sys_choice_set>
+        <sys_choice action="INSERT_OR_UPDATE">
+            <dependent_value/>
+            <element>fs_form_7600b_use_g_invoicing</element>
+            <hint/>
+            <inactive>false</inactive>
+            <label>NO</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sequence/>
+            <synonyms/>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:38:34</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>e9fb722d97713110aba7325e6253af7d</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:38:34</sys_updated_on>
+            <value>NO</value>
+        </sys_choice>
+        <sys_choice action="INSERT_OR_UPDATE">
+            <dependent_value/>
+            <element>fs_form_7600b_use_g_invoicing</element>
+            <hint/>
+            <inactive>false</inactive>
+            <label>YES</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <sequence/>
+            <synonyms/>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:38:25</sys_created_on>
+            <sys_domain>global</sys_domain>
+            <sys_domain_path>/</sys_domain_path>
+            <sys_id>faeb3a2d97713110aba7325e6253af0f</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:38:25</sys_updated_on>
+            <value>YES</value>
+        </sys_choice>
+    </sys_choice>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/author_elective_update/sys_choice_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
@@ -15,45 +15,5 @@
             <sys_updated_by>david.pietrzak</sys_updated_by>
             <sys_updated_on>2023-10-10 13:38:25</sys_updated_on>
         </sys_choice_set>
-        <sys_choice action="INSERT_OR_UPDATE">
-            <dependent_value/>
-            <element>fs_form_7600b_use_g_invoicing</element>
-            <hint/>
-            <inactive>false</inactive>
-            <label>NO</label>
-            <language>en</language>
-            <name>x_g_dis_atat_funding_request_fs_form</name>
-            <sequence/>
-            <synonyms/>
-            <sys_created_by>david.pietrzak</sys_created_by>
-            <sys_created_on>2023-10-10 13:38:34</sys_created_on>
-            <sys_domain>global</sys_domain>
-            <sys_domain_path>/</sys_domain_path>
-            <sys_id>e9fb722d97713110aba7325e6253af7d</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_updated_by>david.pietrzak</sys_updated_by>
-            <sys_updated_on>2023-10-10 13:38:34</sys_updated_on>
-            <value>NO</value>
-        </sys_choice>
-        <sys_choice action="INSERT_OR_UPDATE">
-            <dependent_value/>
-            <element>fs_form_7600b_use_g_invoicing</element>
-            <hint/>
-            <inactive>false</inactive>
-            <label>YES</label>
-            <language>en</language>
-            <name>x_g_dis_atat_funding_request_fs_form</name>
-            <sequence/>
-            <synonyms/>
-            <sys_created_by>david.pietrzak</sys_created_by>
-            <sys_created_on>2023-10-10 13:38:25</sys_created_on>
-            <sys_domain>global</sys_domain>
-            <sys_domain_path>/</sys_domain_path>
-            <sys_id>faeb3a2d97713110aba7325e6253af0f</sys_id>
-            <sys_mod_count>0</sys_mod_count>
-            <sys_updated_by>david.pietrzak</sys_updated_by>
-            <sys_updated_on>2023-10-10 13:38:25</sys_updated_on>
-            <value>YES</value>
-        </sys_choice>
     </sys_choice>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request_fs_form.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request_fs_form.xml
@@ -2,19 +2,13 @@
     <element db_object_id="e5a1ae3b975d7110aba7325e6253af5c" label="DAPPS:Funding Request FS Form" max_length="40" name="x_g_dis_atat_funding_request_fs_form" type="collection">
         <element label="FS Form 7600A Attachment" max_length="40" name="fs_form_7600a_attachment" type="file_attachment"/>
         <element label="FS Form 7600A Filename" max_length="256" name="fs_form_7600a_filename" type="string"/>
-        <element choice="1" label="FS Form 7600A Use G-Invoicing" max_length="40" name="fs_form_7600a_use_g_invoicing" type="choice">
-            <choice>
-                <element inactive_on_update="false" label="NO" value="NO"/>
-                <element inactive_on_update="false" label="YES" value="YES"/>
-            </choice>
+        <element choice="1" choice_field="can_access_package" choice_table="x_g_dis_atat_contacts" label="FS Form 7600A Use G-Invoicing" max_length="40" name="fs_form_7600a_use_g_invoicing" type="choice">
+            <choice/>
         </element>
         <element label="FS Form 7600B Attachment" max_length="40" name="fs_form_7600b_attachment" type="file_attachment"/>
         <element label="FS Form 7600B Filename" max_length="256" name="fs_form_7600b_filename" type="string"/>
-        <element choice="1" label="FS Form 7600B Use G-Invoicing" max_length="40" name="fs_form_7600b_use_g_invoicing" type="choice">
-            <choice>
-                <element inactive_on_update="false" label="NO" value="NO"/>
-                <element inactive_on_update="false" label="YES" value="YES"/>
-            </choice>
+        <element choice="1" choice_field="can_access_package" choice_table="x_g_dis_atat_contacts" label="FS Form 7600B Use G-Invoicing" max_length="40" name="fs_form_7600b_use_g_invoicing" type="choice">
+            <choice/>
         </element>
         <element label="GT&amp;C Number" max_length="22" name="gt_c_number" type="string"/>
         <element label="Order Number" max_length="22" name="order_number" type="string"/>

--- a/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request_fs_form.xml
+++ b/f600233d1b154d507b782f84604bcb12/dictionary/x_g_dis_atat_funding_request_fs_form.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?><database>
-    <element label="Funding Request FS Form" max_length="40" name="x_g_dis_atat_funding_request_fs_form" type="collection">
+    <element db_object_id="e5a1ae3b975d7110aba7325e6253af5c" label="DAPPS:Funding Request FS Form" max_length="40" name="x_g_dis_atat_funding_request_fs_form" type="collection">
         <element label="FS Form 7600A Attachment" max_length="40" name="fs_form_7600a_attachment" type="file_attachment"/>
         <element label="FS Form 7600A Filename" max_length="256" name="fs_form_7600a_filename" type="string"/>
+        <element choice="1" label="FS Form 7600A Use G-Invoicing" max_length="40" name="fs_form_7600a_use_g_invoicing" type="choice">
+            <choice>
+                <element inactive_on_update="false" label="NO" value="NO"/>
+                <element inactive_on_update="false" label="YES" value="YES"/>
+            </choice>
+        </element>
         <element label="FS Form 7600B Attachment" max_length="40" name="fs_form_7600b_attachment" type="file_attachment"/>
         <element label="FS Form 7600B Filename" max_length="256" name="fs_form_7600b_filename" type="string"/>
+        <element choice="1" label="FS Form 7600B Use G-Invoicing" max_length="40" name="fs_form_7600b_use_g_invoicing" type="choice">
+            <choice>
+                <element inactive_on_update="false" label="NO" value="NO"/>
+                <element inactive_on_update="false" label="YES" value="YES"/>
+            </choice>
+        </element>
         <element label="GT&amp;C Number" max_length="22" name="gt_c_number" type="string"/>
         <element label="Order Number" max_length="22" name="order_number" type="string"/>
         <element choice="1" choice_field="can_access_package" choice_table="x_g_dis_atat_contacts" label="Use G-Invoicing" max_length="40" name="use_g_invoicing" type="choice">

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
@@ -11,8 +11,8 @@
 
 })(current);]]></calculation>
         <choice>1</choice>
-        <choice_field/>
-        <choice_table/>
+        <choice_field>can_access_package</choice_field>
+        <choice_table>x_g_dis_atat_contacts</choice_table>
         <column_label>FS Form 7600A Use G-Invoicing</column_label>
         <comments/>
         <create_roles/>
@@ -58,7 +58,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing</sys_update_name>
         <sys_updated_by>david.pietrzak</sys_updated_by>
-        <sys_updated_on>2023-10-10 13:34:22</sys_updated_on>
+        <sys_updated_on>2023-10-11 15:20:15</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="fs_form_7600a_use_g_invoicing" table="x_g_dis_atat_funding_request_fs_form">
+        <active>true</active>
+        <array>false</array>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice>1</choice>
+        <choice_field/>
+        <choice_table/>
+        <column_label>FS Form 7600A Use G-Invoicing</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>fs_form_7600a_use_g_invoicing</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="Choice">choice</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>40</max_length>
+        <name>x_g_dis_atat_funding_request_fs_form</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>david.pietrzak</sys_created_by>
+        <sys_created_on>2023-10-10 13:34:22</sys_created_on>
+        <sys_name>FS Form 7600A Use G-Invoicing</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing</sys_update_name>
+        <sys_updated_by>david.pietrzak</sys_updated_by>
+        <sys_updated_on>2023-10-10 13:34:22</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
@@ -11,8 +11,8 @@
 
 })(current);]]></calculation>
         <choice>1</choice>
-        <choice_field/>
-        <choice_table/>
+        <choice_field>can_access_package</choice_field>
+        <choice_table>x_g_dis_atat_contacts</choice_table>
         <column_label>FS Form 7600B Use G-Invoicing</column_label>
         <comments/>
         <create_roles/>
@@ -58,7 +58,7 @@
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing</sys_update_name>
         <sys_updated_by>david.pietrzak</sys_updated_by>
-        <sys_updated_on>2023-10-10 13:38:14</sys_updated_on>
+        <sys_updated_on>2023-10-11 15:21:19</sys_updated_on>
         <table_reference>false</table_reference>
         <text_index>false</text_index>
         <unique>false</unique>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_dictionary action="INSERT_OR_UPDATE" element="fs_form_7600b_use_g_invoicing" table="x_g_dis_atat_funding_request_fs_form">
+        <active>true</active>
+        <array>false</array>
+        <attributes/>
+        <audit>false</audit>
+        <calculation><![CDATA[(function calculatedFieldValue(current) {
+
+	// Add your code here
+	return '';  // return the calculated value
+
+})(current);]]></calculation>
+        <choice>1</choice>
+        <choice_field/>
+        <choice_table/>
+        <column_label>FS Form 7600B Use G-Invoicing</column_label>
+        <comments/>
+        <create_roles/>
+        <default_value/>
+        <defaultsort/>
+        <delete_roles/>
+        <dependent/>
+        <dependent_on_field/>
+        <display>false</display>
+        <dynamic_creation>false</dynamic_creation>
+        <dynamic_creation_script/>
+        <dynamic_default_value/>
+        <dynamic_ref_qual/>
+        <element>fs_form_7600b_use_g_invoicing</element>
+        <element_reference>false</element_reference>
+        <foreign_database/>
+        <formula/>
+        <function_definition/>
+        <function_field>false</function_field>
+        <internal_type display_value="Choice">choice</internal_type>
+        <mandatory>false</mandatory>
+        <max_length>40</max_length>
+        <name>x_g_dis_atat_funding_request_fs_form</name>
+        <next_element/>
+        <primary>false</primary>
+        <read_only>false</read_only>
+        <read_roles/>
+        <reference/>
+        <reference_cascade_rule/>
+        <reference_floats>false</reference_floats>
+        <reference_key/>
+        <reference_qual/>
+        <reference_qual_condition/>
+        <reference_type/>
+        <spell_check>false</spell_check>
+        <staged>false</staged>
+        <sys_class_name>sys_dictionary</sys_class_name>
+        <sys_created_by>david.pietrzak</sys_created_by>
+        <sys_created_on>2023-10-10 13:38:14</sys_created_on>
+        <sys_name>FS Form 7600B Use G-Invoicing</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_dictionary_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing</sys_update_name>
+        <sys_updated_by>david.pietrzak</sys_updated_by>
+        <sys_updated_on>2023-10-10 13:38:14</sys_updated_on>
+        <table_reference>false</table_reference>
+        <text_index>false</text_index>
+        <unique>false</unique>
+        <use_dependent_field>false</use_dependent_field>
+        <use_dynamic_default>false</use_dynamic_default>
+        <use_reference_qualifier>simple</use_reference_qualifier>
+        <virtual>false</virtual>
+        <virtual_type>script</virtual_type>
+        <widget/>
+        <write_roles/>
+        <xml_view>false</xml_view>
+    </sys_dictionary>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing_en.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="fs_form_7600a_use_g_invoicing" label="FS Form 7600A Use G-Invoicing" language="en" table="x_g_dis_atat_funding_request_fs_form">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>fs_form_7600a_use_g_invoicing</element>
+            <help/>
+            <hint/>
+            <label>FS Form 7600A Use G-Invoicing</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <plural>FS Form 7600A Use G-Invoicings</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:34:22</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>FS Form 7600A Use G-Invoicing</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600a_use_g_invoicing_en</sys_update_name>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:34:22</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing_en.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing_en.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update>
+    <sys_documentation element="fs_form_7600b_use_g_invoicing" label="FS Form 7600B Use G-Invoicing" language="en" table="x_g_dis_atat_funding_request_fs_form">
+        <sys_documentation action="INSERT_OR_UPDATE">
+            <element>fs_form_7600b_use_g_invoicing</element>
+            <help/>
+            <hint/>
+            <label>FS Form 7600B Use G-Invoicing</label>
+            <language>en</language>
+            <name>x_g_dis_atat_funding_request_fs_form</name>
+            <plural>FS Form 7600B Use G-Invoicings</plural>
+            <sys_class_name>sys_documentation</sys_class_name>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:38:14</sys_created_on>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_name>FS Form 7600B Use G-Invoicing</sys_name>
+            <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+            <sys_policy/>
+            <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+            <sys_update_name>sys_documentation_x_g_dis_atat_funding_request_fs_form_fs_form_7600b_use_g_invoicing_en</sys_update_name>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:38:14</sys_updated_on>
+            <url/>
+            <url_target/>
+        </sys_documentation>
+    </sys_documentation>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_1003ea77dbee65108c045e8cd39619f3.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ui_section_1003ea77dbee65108c045e8cd39619f3.xml
@@ -140,6 +140,34 @@
             <sys_user/>
             <type/>
         </sys_ui_element>
+        <sys_ui_element action="INSERT_OR_UPDATE">
+            <element>fs_form_7600a_use_g_invoicing</element>
+            <position>10</position>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:34:22</sys_created_on>
+            <sys_id>7c0bf6e997713110aba7325e6253af7e</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_ui_formatter/>
+            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_funding_request_fs_form" sys_domain="global" view="Default view">1003ea77dbee65108c045e8cd39619f3</sys_ui_section>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:34:22</sys_updated_on>
+            <sys_user/>
+            <type/>
+        </sys_ui_element>
+        <sys_ui_element action="INSERT_OR_UPDATE">
+            <element>fs_form_7600b_use_g_invoicing</element>
+            <position>11</position>
+            <sys_created_by>david.pietrzak</sys_created_by>
+            <sys_created_on>2023-10-10 13:38:14</sys_created_on>
+            <sys_id>2debf6e997713110aba7325e6253af19</sys_id>
+            <sys_mod_count>0</sys_mod_count>
+            <sys_ui_formatter/>
+            <sys_ui_section caption="NULL" display_value="" name="x_g_dis_atat_funding_request_fs_form" sys_domain="global" view="Default view">1003ea77dbee65108c045e8cd39619f3</sys_ui_section>
+            <sys_updated_by>david.pietrzak</sys_updated_by>
+            <sys_updated_on>2023-10-10 13:38:14</sys_updated_on>
+            <sys_user/>
+            <type/>
+        </sys_ui_element>
         <sys_ui_section action="INSERT_OR_UPDATE">
             <caption/>
             <header>false</header>


### PR DESCRIPTION
Added independent use_g_invoicing fields for 7600a and 7600b

Use G-Invoicing was the old field, and this is to be removed and a migration script written in a future sprint.
<img width="1481" alt="Screenshot 2023-10-11 at 5 59 46 AM" src="https://github.com/dod-ccpo/atat-snow/assets/145709186/a0aed321-8bf1-401b-aaea-f805dfdc7c7a">
<img width="1481" alt="Screenshot 2023-10-11 at 5 59 56 AM" src="https://github.com/dod-ccpo/atat-snow/assets/145709186/504328dd-1ce5-4719-89e0-00749964cfa3">
