### PR TITLE
Feature/at 9830 reconfigure ginvoicing api gtc

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
@@ -52,6 +52,8 @@ GInvoicing.prototype = {
 			throw "XML invalid: " + xmlValidationErrors;
 		}
 	},		
+	
+	// TODO add new methods for getOrder and getGtc in the G-invoicing Script Include, both of which would invoke getPayload while passing in the full endpoints. also change the error handling in getPayload to throw an error if the status code is not 200 and have separate catch blocks in getOrder and getGtc to handle the errors
 
 	getPayload: function(input) {
 		var http_payload;
@@ -104,13 +106,13 @@ GInvoicing.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-05-24 16:22:32</sys_created_on>
         <sys_id>60a96b74db8fa5908c045e8cd3961955</sys_id>
-        <sys_mod_count>26</sys_mod_count>
+        <sys_mod_count>27</sys_mod_count>
         <sys_name>GInvoicing</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_60a96b74db8fa5908c045e8cd3961955</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-10-12 15:26:21</sys_updated_on>
+        <sys_updated_on>2023-10-12 19:24:50</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
@@ -67,7 +67,6 @@ GInvoicing.prototype = {
 		gInvoicingEndpoint = input.endpoint + "/" + input.gtc_Number;
 		}
 		request.setEndpoint(gInvoicingEndpoint);
-		gs.info("here's the endpoint"+ gInvoicingEndpoint );
 		request.setHttpMethod("get");
 		request.setLogLevel("all");
 		request.setMutualAuth("g-invoicing-mauth");
@@ -75,7 +74,6 @@ GInvoicing.prototype = {
 
 		// Make request
 		var response = request.execute();
-		gs.info("here's response" + JSON.stringify(response));
 		// Check for errors
 		if(response.getStatusCode() != "200"){
 			gs.error(response.getStatusCode());
@@ -106,13 +104,13 @@ GInvoicing.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-05-24 16:22:32</sys_created_on>
         <sys_id>60a96b74db8fa5908c045e8cd3961955</sys_id>
-        <sys_mod_count>25</sys_mod_count>
+        <sys_mod_count>26</sys_mod_count>
         <sys_name>GInvoicing</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_60a96b74db8fa5908c045e8cd3961955</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-10-12 14:47:05</sys_updated_on>
+        <sys_updated_on>2023-10-12 15:26:21</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_60a96b74db8fa5908c045e8cd3961955.xml
@@ -26,10 +26,14 @@ GInvoicing.prototype = {
 		var fsForm = new GlideRecord("x_g_dis_atat_funding_request_fs_form");
 		fsForm.get(fundingRequest.fs_form);
 		if (!fsForm.sys_id) {
-			"No FS Form record found";
+			throw "No FS Form record found";
 		}
+		if(gtcNumber) {
 		fsForm.gt_c_number = gtcNumber;
+		}
+		if(orderNumber) {
 		fsForm.order_number = orderNumber;
+		}
 		fsForm.update();
 	},
 	
@@ -55,8 +59,15 @@ GInvoicing.prototype = {
 		var request = new sn_ws.RESTMessageV2();
 
 		// Request set-up
-		var gInvoicingEndpoint = input.endpoint + "/" + input.order_number;
+		let gInvoicingEndpoint = null;
+		if (input.order_number){
+		gInvoicingEndpoint = input.endpoint + "/" + input.order_number;
+		}
+		else if (input.gtc_Number) {
+		gInvoicingEndpoint = input.endpoint + "/" + input.gtc_Number;
+		}
 		request.setEndpoint(gInvoicingEndpoint);
+		gs.info("here's the endpoint"+ gInvoicingEndpoint );
 		request.setHttpMethod("get");
 		request.setLogLevel("all");
 		request.setMutualAuth("g-invoicing-mauth");
@@ -64,13 +75,21 @@ GInvoicing.prototype = {
 
 		// Make request
 		var response = request.execute();
+		gs.info("here's response" + JSON.stringify(response));
 		// Check for errors
 		if(response.getStatusCode() != "200"){
 			gs.error(response.getStatusCode());
 			gs.error(response.getBody());
+			let errorMessage = null;
+			if (input.order_number){
+				errorMessage = "Could not find a G-Invoicing Order with number " + input.order_number;
+			}
+			else if (input.gtc_Number) {
+				errorMessage = "Could not find a GT&C with number " + input.gtc_Number;
+			}
 			throw {
 				statusCode: response.getStatusCode(),
-				message: "Could not find a G-Invoicing Order with number " + input.order_number
+				message: errorMessage
 			};
 		}
 		http_payload = {
@@ -87,13 +106,13 @@ GInvoicing.prototype = {
         <sys_created_by>1370228783.CTR</sys_created_by>
         <sys_created_on>2023-05-24 16:22:32</sys_created_on>
         <sys_id>60a96b74db8fa5908c045e8cd3961955</sys_id>
-        <sys_mod_count>18</sys_mod_count>
+        <sys_mod_count>25</sys_mod_count>
         <sys_name>GInvoicing</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_60a96b74db8fa5908c045e8cd3961955</sys_update_name>
-        <sys_updated_by>1370228783.CTR</sys_updated_by>
-        <sys_updated_on>2023-05-25 15:36:26</sys_updated_on>
+        <sys_updated_by>torin.harthcock</sys_updated_by>
+        <sys_updated_on>2023-10-12 14:47:05</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_798394b597fd31103394f5b0f053af2c.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_798394b597fd31103394f5b0f053af2c.xml
@@ -32,7 +32,7 @@
 	try {
 		let ginv = new GInvoicing();
 		let response = ginv.getPayload(payload);
-		if (response.status_code !== "200") {
+		if (response.status_code !== 200) {
 			throw "Could not find GTC Number";
 		}
 		else {
@@ -58,14 +58,14 @@
         <sys_created_by>torin.harthcock</sys_created_by>
         <sys_created_on>2023-10-11 16:59:48</sys_created_on>
         <sys_id>798394b597fd31103394f5b0f053af2c</sys_id>
-        <sys_mod_count>17</sys_mod_count>
+        <sys_mod_count>21</sys_mod_count>
         <sys_name>GTC Validation</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_ws_operation_798394b597fd31103394f5b0f053af2c</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-10-12 14:50:14</sys_updated_on>
+        <sys_updated_on>2023-10-12 15:35:56</sys_updated_on>
         <web_service_definition display_value="G-Invoicing">c6c3fe7f1b6091107c458623604bcb39</web_service_definition>
         <web_service_version/>
     </sys_ws_operation>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_798394b597fd31103394f5b0f053af2c.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_798394b597fd31103394f5b0f053af2c.xml
@@ -6,17 +6,17 @@
         <default_operation_uri/>
         <enforce_acl>cf9d01d3e73003009d6247e603f6a990</enforce_acl>
         <http_method>GET</http_method>
-        <name>Order Validation</name>
+        <name>GTC Validation</name>
         <operation_script><![CDATA[(function process(/*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
 	
-	var gInvoicingEndpoint = gs.getProperty("x_g_dis_atat.gInvoicing.baseUrl") + "/ginv/services/v2_0/order";
+	var gInvoicingEndpoint = gs.getProperty("x_g_dis_atat.gInvoicing.baseUrl") + "/ginv/services/v2_0/gtc";
 	var atatSystemId = gs.getProperty("x_g_dis_atat.gInvoicing.systemId");
 	var queryParams = request.queryParams;
-	var orderNumber = queryParams.orderNumber;
+	var gtcNumber = queryParams.gtcNumber;
 	var acquisitionPackageId = queryParams.acquisitionPackageId;
 	
-	if (!orderNumber) {
-		throw "orderNumber required";
+	if (!gtcNumber) {
+		throw "gtcNumber required";
 	}
 	if (!acquisitionPackageId) {
 		throw "acquisitionPackageId required";
@@ -26,19 +26,18 @@
 	var payload = {
 		atat_system_id: atatSystemId,
 		endpoint: gInvoicingEndpoint,
-		order_number: orderNumber.toString()		
+		gtc_Number: gtcNumber.toString()		
 	};
 	
 	try {
 		let ginv = new GInvoicing();
 		let response = ginv.getPayload(payload);
-		gs.info("here's response from order payload" +JSON.stringify(response.status_code));
 		if (response.status_code !== "200") {
-			throw "Could not find Order Number";
+			throw "Could not find GTC Number";
 		}
 		else {
-			ginv.updatePackage(acquisitionPackageId.toString(), null, orderNumber.toString());
-			return orderNumber.toString();
+			ginv.updatePackage(acquisitionPackageId.toString(), gtcNumber.toString(), null);
+			return gtcNumber.toString();
 		}			
 	} catch (error) {
 		response.setStatus(error.statusCode);
@@ -46,27 +45,27 @@
 	}
 	
 })(request, response);]]></operation_script>
-        <operation_uri>/api/x_g_dis_atat/g_invoicing/order_validation</operation_uri>
+        <operation_uri>/api/x_g_dis_atat/g_invoicing/gtc_validation</operation_uri>
         <produces>application/json,application/xml,text/xml</produces>
         <produces_customized>false</produces_customized>
-        <relative_path>/order_validation</relative_path>
+        <relative_path>/gtc_validation</relative_path>
         <request_example/>
         <requires_acl_authorization>true</requires_acl_authorization>
-        <requires_authentication>false</requires_authentication>
-        <requires_snc_internal_role>false</requires_snc_internal_role>
+        <requires_authentication>true</requires_authentication>
+        <requires_snc_internal_role>true</requires_snc_internal_role>
         <short_description/>
         <sys_class_name>sys_ws_operation</sys_class_name>
-        <sys_created_by>zach.clark</sys_created_by>
-        <sys_created_on>2022-07-14 17:11:33</sys_created_on>
-        <sys_id>af147e7f1b6091107c458623604bcb3f</sys_id>
-        <sys_mod_count>30</sys_mod_count>
-        <sys_name>Order Validation</sys_name>
+        <sys_created_by>torin.harthcock</sys_created_by>
+        <sys_created_on>2023-10-11 16:59:48</sys_created_on>
+        <sys_id>798394b597fd31103394f5b0f053af2c</sys_id>
+        <sys_mod_count>17</sys_mod_count>
+        <sys_name>GTC Validation</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
-        <sys_update_name>sys_ws_operation_af147e7f1b6091107c458623604bcb3f</sys_update_name>
+        <sys_update_name>sys_ws_operation_798394b597fd31103394f5b0f053af2c</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-10-12 14:50:18</sys_updated_on>
+        <sys_updated_on>2023-10-12 14:50:14</sys_updated_on>
         <web_service_definition display_value="G-Invoicing">c6c3fe7f1b6091107c458623604bcb39</web_service_definition>
         <web_service_version/>
     </sys_ws_operation>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_af147e7f1b6091107c458623604bcb3f.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_operation_af147e7f1b6091107c458623604bcb3f.xml
@@ -33,7 +33,7 @@
 		let ginv = new GInvoicing();
 		let response = ginv.getPayload(payload);
 		gs.info("here's response from order payload" +JSON.stringify(response.status_code));
-		if (response.status_code !== "200") {
+		if (response.status_code !== 200) {
 			throw "Could not find Order Number";
 		}
 		else {
@@ -59,14 +59,14 @@
         <sys_created_by>zach.clark</sys_created_by>
         <sys_created_on>2022-07-14 17:11:33</sys_created_on>
         <sys_id>af147e7f1b6091107c458623604bcb3f</sys_id>
-        <sys_mod_count>30</sys_mod_count>
+        <sys_mod_count>31</sys_mod_count>
         <sys_name>Order Validation</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_ws_operation_af147e7f1b6091107c458623604bcb3f</sys_update_name>
         <sys_updated_by>torin.harthcock</sys_updated_by>
-        <sys_updated_on>2023-10-12 14:50:18</sys_updated_on>
+        <sys_updated_on>2023-10-12 15:34:48</sys_updated_on>
         <web_service_definition display_value="G-Invoicing">c6c3fe7f1b6091107c458623604bcb39</web_service_definition>
         <web_service_version/>
     </sys_ws_operation>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_269cacc2977131103394f5b0f053af81.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_269cacc2977131103394f5b0f053af81.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter">
+    <sys_ws_query_parameter action="INSERT_OR_UPDATE">
+        <example_value>A2208-097-097-017190</example_value>
+        <name>gtcNumber</name>
+        <required>false</required>
+        <short_description/>
+        <sys_class_name>sys_ws_query_parameter</sys_class_name>
+        <sys_created_by>torin.harthcock</sys_created_by>
+        <sys_created_on>2023-10-11 16:29:30</sys_created_on>
+        <sys_id>269cacc2977131103394f5b0f053af81</sys_id>
+        <sys_mod_count>1</sys_mod_count>
+        <sys_name>gtcNumber</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_269cacc2977131103394f5b0f053af81</sys_update_name>
+        <sys_updated_by>torin.harthcock</sys_updated_by>
+        <sys_updated_on>2023-10-11 16:30:48</sys_updated_on>
+        <web_service_definition display_value="G-Invoicing">c6c3fe7f1b6091107c458623604bcb39</web_service_definition>
+    </sys_ws_query_parameter>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_ce4c308297b131103394f5b0f053af2f.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_ce4c308297b131103394f5b0f053af2f.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter_map">
+    <sys_ws_query_parameter_map action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_ws_query_parameter_map</sys_class_name>
+        <sys_created_by>torin.harthcock</sys_created_by>
+        <sys_created_on>2023-10-11 17:37:56</sys_created_on>
+        <sys_id>ce4c308297b131103394f5b0f053af2f</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>bb532bfcdb4fa5908c045e8cd3961916</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_map_ce4c308297b131103394f5b0f053af2f</sys_update_name>
+        <sys_updated_by>torin.harthcock</sys_updated_by>
+        <sys_updated_on>2023-10-11 17:37:56</sys_updated_on>
+        <web_service_operation display_value="GTC Validation">798394b597fd31103394f5b0f053af2c</web_service_operation>
+        <web_service_query_parameter display_value="acquisitionPackageId">bb532bfcdb4fa5908c045e8cd3961916</web_service_query_parameter>
+    </sys_ws_query_parameter_map>
+</record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_d87c708297b131103394f5b0f053af81.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_ws_query_parameter_map_d87c708297b131103394f5b0f053af81.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter_map">
+    <sys_ws_query_parameter_map action="INSERT_OR_UPDATE">
+        <sys_class_name>sys_ws_query_parameter_map</sys_class_name>
+        <sys_created_by>torin.harthcock</sys_created_by>
+        <sys_created_on>2023-10-11 17:38:27</sys_created_on>
+        <sys_id>d87c708297b131103394f5b0f053af81</sys_id>
+        <sys_mod_count>0</sys_mod_count>
+        <sys_name>269cacc2977131103394f5b0f053af81</sys_name>
+        <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
+        <sys_policy/>
+        <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
+        <sys_update_name>sys_ws_query_parameter_map_d87c708297b131103394f5b0f053af81</sys_update_name>
+        <sys_updated_by>torin.harthcock</sys_updated_by>
+        <sys_updated_on>2023-10-11 17:38:27</sys_updated_on>
+        <web_service_operation display_value="GTC Validation">798394b597fd31103394f5b0f053af2c</web_service_operation>
+        <web_service_query_parameter display_value="gtcNumber">269cacc2977131103394f5b0f053af81</web_service_query_parameter>
+    </sys_ws_query_parameter_map>
+</record_update>


### PR DESCRIPTION
now there are 2 separate API calls, one for order number and one for GTC number:
![image](https://github.com/dod-ccpo/atat-snow/assets/137221301/62a5c917-e4b1-4aa9-abe1-97745639c1eb)
adjusted corresponding script include to account for both possible uses:
![image](https://github.com/dod-ccpo/atat-snow/assets/137221301/617058f4-01ae-461d-a500-be9cec86741a)

Linked to corresponding UI PR as well: 
https://github.com/dod-ccpo/atat-web-ui/pull/2031