### PR TITLE
AT-10111

### DIFF
--- a/f600233d1b154d507b782f84604bcb12/update/sys_script_include_71eea70447427110ee827d7ba26d43e5.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sys_script_include_71eea70447427110ee827d7ba26d43e5.xml
@@ -13,6 +13,7 @@
         this.ALERT_TYPE_FUNDS = "funds";
         this.ALERT_TYPE_TIME = "time";
 
+		this.CLINS_TABLE = "x_g_dis_atat_clin";
         this.PREFERENCES_TABLE = "x_g_dis_atat_preferences";
         this.USER_TABLE = "sys_user";
         this.TRACKING_TABLE = "x_g_dis_atat_alerts_tracking";
@@ -60,11 +61,11 @@
         const gr = new GlideRecord(this.TRACKING_TABLE);
         if (gr.get(records[0].sys_id)) {
             if (records[0].alert.type === this.ALERT_TYPE_FUNDS) {
-                this.handleAlert(gr, records[0], this.QUEUE_FUNDS);
+                this.handleFundingAlert(gr, records[0]);
             } else if (records[0].alert.type === this.ALERT_TYPE_TIME 
                        && !timeAlerts.includes(records[0].portfolio)) {
                 timeAlerts.push(records[0].portfolio);
-                this.handleAlert(gr, records[0], this.QUEUE_TIME);
+                this.handleTimeAlert(gr, records[0]);
             }
             gr.status = 'processed';
             gr.update();
@@ -78,44 +79,45 @@
         });
     }
 
-    updateTrackingRecordsOld(records, timeAlerts, fundAlerts) {
-        const gr = new GlideRecord(this.TRACKING_TABLE);
-
-        if (gr.get(records[0])) {
-            if (record.alert.type === this.ALERT_TYPE_FUNDS) {
-                fundAlerts.push(record.sys_id);
-                this.handleAlert(gr, record, this.QUEUE_FUNDS);
-                // only one time alert per portfolio
-            } else if (record.alert.type === this.ALERT_TYPE_TIME && !timeAlerts.includes(record.portfolio)) {
-                timeAlerts.push(record.portfolio);
-                this.handleAlert(gr, record, this.QUEUE_TIME);
-            }
-
-            gr.status = 'processed';
-            gr.update();
-        }
-
-        records.slice(1).forEach(record => {
-            if (gr.get(record.sys_id)) {
-                gr.status = 'omitted';
-                gr.update();
-            }
-        });
-    }
-
-    handleAlert(gr, alert, queue) {
+    handleFundingAlert(gr, alert, queue) {
         const userSysIds = this.extractUserSysIds(gr);
         new global.GlideQuery(this.USER_TABLE)
             .where('sys_id', 'IN', userSysIds)
             .select('email')
             .toArray(100)
             .forEach((user) => {
-                gs.eventQueue(queue,
+                gs.eventQueue(this.QUEUE_FUNDS,
                     gr,
-                    user.email,
-                    gr.portfolio.active_task_order.getDisplayValue());
+                    user.email);
             });
     }
+	
+	// Time Alerts need in-period CLINS for the email template yet I have not figured out
+	// why I can't make a GlideRecord/Query call in an email script include, so, I am
+	// passing them along as event.parm2 on the queue.
+	handleTimeAlert(gr, alert, clins) {
+        const userSysIds = this.extractUserSysIds(gr);
+		const now = new GlideDate();
+
+		const inPeriodClins = new global.GlideQuery(this.CLINS_TABLE)
+                .where('task_order', gr.portfolio.active_task_order)
+                .where('pop_start_date', '<=', now.getValue())
+                .where('pop_end_date', '>', now.getValue())
+                .select('clin_number')
+                .toArray(100)
+                .map((clin) => ` ${clin.clin_number}`);
+		
+        new global.GlideQuery(this.USER_TABLE)
+            .where('sys_id', 'IN', userSysIds)
+            .select('email')
+            .toArray(100)
+            .forEach((user) => {
+                gs.eventQueue(this.QUEUE_TIME,
+                    gr,
+                    user.email,
+                    inPeriodClins);
+            });
+	}
 
     extractUserSysIds(gr) {
         let emails = [];
@@ -137,13 +139,13 @@
         <sys_created_by>stephen.hayes</sys_created_by>
         <sys_created_on>2023-10-18 11:47:30</sys_created_on>
         <sys_id>71eea70447427110ee827d7ba26d43e5</sys_id>
-        <sys_mod_count>132</sys_mod_count>
+        <sys_mod_count>142</sys_mod_count>
         <sys_name>AlertProcessor</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy>read</sys_policy>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sys_script_include_71eea70447427110ee827d7ba26d43e5</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-10-27 18:34:06</sys_updated_on>
+        <sys_updated_on>2023-10-31 12:26:56</sys_updated_on>
     </sys_script_include>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sysevent_email_template_19f751e44746b110ee827d7ba26d432e.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sysevent_email_template_19f751e44746b110ee827d7ba26d432e.xml
@@ -104,19 +104,19 @@
         <message_text/>
         <name>Alert (Funds)</name>
         <sms_alternate/>
-        <subject>ATAT portfolio alert for "${portfolio}" - Task Order ${event.parm2}</subject>
+        <subject>ATAT portfolio alert for "${portfolio}" - Task Order ${clin.task_order.task_order_number}</subject>
         <sys_class_name>sysevent_email_template</sys_class_name>
         <sys_created_by>stephen.hayes</sys_created_by>
         <sys_created_on>2023-10-19 14:03:53</sys_created_on>
         <sys_id>19f751e44746b110ee827d7ba26d432e</sys_id>
-        <sys_mod_count>13</sys_mod_count>
+        <sys_mod_count>14</sys_mod_count>
         <sys_name>Alert (Funds)</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sysevent_email_template_19f751e44746b110ee827d7ba26d432e</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-10-25 20:16:47</sys_updated_on>
+        <sys_updated_on>2023-10-31 12:23:18</sys_updated_on>
         <sys_version>2</sys_version>
     </sysevent_email_template>
 </record_update>

--- a/f600233d1b154d507b782f84604bcb12/update/sysevent_email_template_e1185da44746b110ee827d7ba26d436a.xml
+++ b/f600233d1b154d507b782f84604bcb12/update/sysevent_email_template_e1185da44746b110ee827d7ba26d436a.xml
@@ -92,7 +92,7 @@
 <p class="title-text">Period of Performance alert for Task Order #${portfolio.active_task_order.task_order_number}</p>
 <div class="body-text">
 <p><strong>The Account Tracking Automation Tool (ATAT) reflects that the following Contract Line Item Numbers (CLINs) are within ${alert.threshold} days of expiring.</strong></p>
-<p><strong>CLINs: ${portfolio.active_task_order.clins}</strong> - Expiring ${mail_script:atat_date_display}</p>
+<p><strong>CLINs: ${event.parm2}</strong> - Expiring ${mail_script:atat_date_display}</p>
 <p class="body-text">You may need to request a task order modification or initiate a follow-on task order to update the funding associated with your "${portfolio.name}" portfolio.</p>
 <p class="body-text">To review your task order details and portfolio spend, login to ATAT by clicking the link below:</p>
 <a class="button" href="https://services.disa.mil/dapps-atat"> View ATAT Portfolio </a></div>
@@ -105,19 +105,19 @@
         <message_text/>
         <name>Alert (Time)</name>
         <sms_alternate/>
-        <subject>ATAT portfolio alert for "${portfolio}" - Task Order ${event.parm2}</subject>
+        <subject>ATAT portfolio alert for "${portfolio}" - Task Order ${clin.task_order.task_order_number}</subject>
         <sys_class_name>sysevent_email_template</sys_class_name>
         <sys_created_by>stephen.hayes</sys_created_by>
         <sys_created_on>2023-10-19 14:04:22</sys_created_on>
         <sys_id>e1185da44746b110ee827d7ba26d436a</sys_id>
-        <sys_mod_count>32</sys_mod_count>
+        <sys_mod_count>38</sys_mod_count>
         <sys_name>Alert (Time)</sys_name>
         <sys_package display_value="ATAT" source="x_g_dis_atat">f600233d1b154d507b782f84604bcb12</sys_package>
         <sys_policy/>
         <sys_scope display_value="ATAT">f600233d1b154d507b782f84604bcb12</sys_scope>
         <sys_update_name>sysevent_email_template_e1185da44746b110ee827d7ba26d436a</sys_update_name>
         <sys_updated_by>stephen.hayes</sys_updated_by>
-        <sys_updated_on>2023-10-27 18:35:40</sys_updated_on>
+        <sys_updated_on>2023-10-31 12:27:39</sys_updated_on>
         <sys_version>2</sys_version>
     </sysevent_email_template>
 </record_update>


### PR DESCRIPTION
- removed TO # from event.parm2 for both queues; this can be referenced in the email template via dot-walking 
- split utility method for queueing alerts into two methods; time and funds, because of requirement to provide in-period CLINs for time alerts. 
- added array of in-period CLINs to event.parm2 for time alerts